### PR TITLE
Extend `Synchronize()`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,14 +31,8 @@ func main() {
 		panic(err)
 	}
 
-	// Determine file type, assign correct handler
-	handler, err := appendable.DetermineDataHandler(args[0])
-	if err != nil {
-		panic(err)
-	}
-
 	// Open the index file
-	indexFile, err := appendable.NewIndexFile(file, handler)
+	indexFile, err := appendable.NewIndexFile(appendable.JSONLHandler{ReadSeeker: file})
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,8 +31,14 @@ func main() {
 		panic(err)
 	}
 
+	// Determine file type, assign correct handler
+	handler, err := appendable.DetermineDataHandler(args[0])
+	if err != nil {
+		panic(err)
+	}
+
 	// Open the index file
-	indexFile, err := appendable.NewIndexFile(file)
+	indexFile, err := appendable.NewIndexFile(file, handler)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/appendable/index_file.go
+++ b/pkg/appendable/index_file.go
@@ -74,7 +74,7 @@ func (i *IndexFile) findIndex(name string, value any) int {
 
 }
 
-func (i *IndexFile) handleObject(dec *json.Decoder, path []string, dataIndex, dataOffset uint64) error {
+func (i *IndexFile) handleJSONLObject(dec *json.Decoder, path []string, dataIndex, dataOffset uint64) error {
 	// while the next token is not }, read the key
 	for dec.More() {
 		key, err := dec.Token()
@@ -141,7 +141,7 @@ func (i *IndexFile) handleObject(dec *json.Decoder, path []string, dataIndex, da
 							i.Indexes[j].FieldType |= protocol.FieldTypeObject
 						}
 					}
-					if err := i.handleObject(dec, append(path, key), dataIndex, dataOffset); err != nil {
+					if err := i.handleJSONLObject(dec, append(path, key), dataIndex, dataOffset); err != nil {
 						return fmt.Errorf("failed to handle object: %w", err)
 					}
 					// read the }

--- a/pkg/appendable/index_file_test.go
+++ b/pkg/appendable/index_file_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAppendDataRow(t *testing.T) {
 	t.Run("no schema changes", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"))
+		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -21,7 +21,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":\"test3\"}\n"))
+		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":\"test3\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -47,7 +47,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("correctly sets field offset", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"))
+		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -58,7 +58,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":\"test3\"}\n"))
+		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":\"test3\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -95,7 +95,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("new index", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"))
+		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -106,7 +106,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":\"test3\"}\n"))
+		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":\"test3\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -126,7 +126,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("existing index but different type", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"))
+		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -137,7 +137,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":123}\n"))
+		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":123}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -153,7 +153,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("creates nested indices", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"))
+		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -164,7 +164,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":{\"a\":1,\"b\":\"2\"}}\n"))
+		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":{\"a\":1,\"b\":\"2\"}}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -200,7 +200,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("creates nested indices but also erases parent", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"))
+		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -211,7 +211,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":{\"a\":1,\"b\":\"2\"}}\n"))
+		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":{\"a\":1,\"b\":\"2\"}}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -227,7 +227,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("ignores arrays", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"))
+		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -238,7 +238,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":[[1,2,3],4]}\n"))
+		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":[[1,2,3],4]}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -250,7 +250,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("ignores arrays but downgrades type", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"))
+		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -261,7 +261,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":[[1,2,3],4]}\n"))
+		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":[[1,2,3],4]}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -277,7 +277,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("existing index but nullable type", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"))
+		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -288,7 +288,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":null}\n"))
+		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":null}\n"), JSONLHandler{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/appendable/index_file_test.go
+++ b/pkg/appendable/index_file_test.go
@@ -10,7 +10,8 @@ import (
 
 func TestAppendDataRow(t *testing.T) {
 	t.Run("no schema changes", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
+
+		i, err := NewIndexFile(JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -21,7 +22,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":\"test3\"}\n"), JSONLHandler{})
+		j, err := ReadIndexFile(buf, JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n{\"test\":\"test3\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -47,7 +48,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("correctly sets field offset", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
+		i, err := NewIndexFile(JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -58,7 +59,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":\"test3\"}\n"), JSONLHandler{})
+		j, err := ReadIndexFile(buf, JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n{\"test\":\"test3\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -95,7 +96,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("new index", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
+		i, err := NewIndexFile(JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -106,7 +107,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":\"test3\"}\n"), JSONLHandler{})
+		j, err := ReadIndexFile(buf, JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":\"test3\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -126,7 +127,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("existing index but different type", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
+		i, err := NewIndexFile(JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -137,7 +138,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":123}\n"), JSONLHandler{})
+		j, err := ReadIndexFile(buf, JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n{\"test\":123}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -153,7 +154,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("creates nested indices", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
+		i, err := NewIndexFile(JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -164,7 +165,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":{\"a\":1,\"b\":\"2\"}}\n"), JSONLHandler{})
+		j, err := ReadIndexFile(buf, JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":{\"a\":1,\"b\":\"2\"}}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -200,7 +201,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("creates nested indices but also erases parent", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
+		i, err := NewIndexFile(JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -211,7 +212,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":{\"a\":1,\"b\":\"2\"}}\n"), JSONLHandler{})
+		j, err := ReadIndexFile(buf, JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n{\"test\":{\"a\":1,\"b\":\"2\"}}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -227,7 +228,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("ignores arrays", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
+		i, err := NewIndexFile(JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -238,7 +239,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":[[1,2,3],4]}\n"), JSONLHandler{})
+		j, err := ReadIndexFile(buf, JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n{\"test2\":[[1,2,3],4]}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -250,7 +251,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("ignores arrays but downgrades type", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
+		i, err := NewIndexFile(JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -261,7 +262,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":[[1,2,3],4]}\n"), JSONLHandler{})
+		j, err := ReadIndexFile(buf, JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n{\"test\":[[1,2,3],4]}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -277,7 +278,7 @@ func TestAppendDataRow(t *testing.T) {
 	})
 
 	t.Run("existing index but nullable type", func(t *testing.T) {
-		i, err := NewIndexFile(strings.NewReader("{\"test\":\"test1\"}\n"), JSONLHandler{})
+		i, err := NewIndexFile(JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -288,7 +289,7 @@ func TestAppendDataRow(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		j, err := ReadIndexFile(buf, strings.NewReader("{\"test\":\"test1\"}\n{\"test\":null}\n"), JSONLHandler{})
+		j, err := ReadIndexFile(buf, JSONLHandler{ReadSeeker: strings.NewReader("{\"test\":\"test1\"}\n{\"test\":null}\n")})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/appendable/io.go
+++ b/pkg/appendable/io.go
@@ -185,7 +185,7 @@ func (j JSONLHandler) Synchronize(f *IndexFile) error {
 			return fmt.Errorf("expected '%U', got '%U' (only json objects are supported at the root)", '{', t)
 		}
 
-		if err := f.handleObject(dec, []string{}, uint64(existingCount), start); err != nil {
+		if err := f.handleJSONLObject(dec, []string{}, uint64(existingCount), start); err != nil {
 			return fmt.Errorf("failed to handle object: %w", err)
 		}
 

--- a/pkg/appendable/io_test.go
+++ b/pkg/appendable/io_test.go
@@ -7,9 +7,38 @@ import (
 	"testing"
 )
 
+func TestDetermineDataHandler(t *testing.T) {
+
+	t.Run("unrecognized file", func(t *testing.T) {
+		filepath := "wef"
+
+		_, err := DetermineDataHandler(filepath)
+
+		if err == nil {
+			t.Errorf("DetermineDataHandler() did not error, expected err")
+		}
+	})
+
+	t.Run("jsonl file", func(t *testing.T) {
+		filePath := "examplewef.jsonl"
+
+		handler, err := DetermineDataHandler(filePath)
+
+		if err != nil {
+			t.Errorf("DetermineDataHandler() returned an unexpected error: %v", err)
+		}
+
+		_, isJSONLHandler := handler.(JSONLHandler)
+
+		if !isJSONLHandler {
+			t.Errorf("DetermineDataHandler() returned incorrect handler type, expected JSONLHandler")
+		}
+	})
+}
+
 func TestReadIndexFile(t *testing.T) {
 	t.Run("empty index file", func(t *testing.T) {
-		if _, err := ReadIndexFile(strings.NewReader(""), strings.NewReader("")); !errors.Is(err, io.EOF) {
+		if _, err := ReadIndexFile(strings.NewReader(""), strings.NewReader(""), JSONLHandler{}); !errors.Is(err, io.EOF) {
 			t.Errorf("expected EOF, got %v", err)
 		}
 	})

--- a/pkg/appendable/io_test.go
+++ b/pkg/appendable/io_test.go
@@ -7,38 +7,9 @@ import (
 	"testing"
 )
 
-func TestDetermineDataHandler(t *testing.T) {
-
-	t.Run("unrecognized file", func(t *testing.T) {
-		filepath := "wef"
-
-		_, err := DetermineDataHandler(filepath)
-
-		if err == nil {
-			t.Errorf("DetermineDataHandler() did not error, expected err")
-		}
-	})
-
-	t.Run("jsonl file", func(t *testing.T) {
-		filePath := "examplewef.jsonl"
-
-		handler, err := DetermineDataHandler(filePath)
-
-		if err != nil {
-			t.Errorf("DetermineDataHandler() returned an unexpected error: %v", err)
-		}
-
-		_, isJSONLHandler := handler.(JSONLHandler)
-
-		if !isJSONLHandler {
-			t.Errorf("DetermineDataHandler() returned incorrect handler type, expected JSONLHandler")
-		}
-	})
-}
-
 func TestReadIndexFile(t *testing.T) {
 	t.Run("empty index file", func(t *testing.T) {
-		if _, err := ReadIndexFile(strings.NewReader(""), strings.NewReader(""), JSONLHandler{}); !errors.Is(err, io.EOF) {
+		if _, err := ReadIndexFile(strings.NewReader(""), JSONLHandler{ReadSeeker: strings.NewReader("")}); !errors.Is(err, io.EOF) {
 			t.Errorf("expected EOF, got %v", err)
 		}
 	})


### PR DESCRIPTION
Because we want to introduce other format types, first we should identify the JSONL specific logic and try to extend them. 

# What this PR contains:
1) `DetermineDataHandler`: a method that checks the suffix of the filepath to identify the format. 

> *Is `strings.HasSuffix` enough? Or should there be more robust measures like content sniffing?*

<br />

2) Since `Serialize()` contains JSONL specific logic + `handleObject`, I wrote an interface `DataHandler` that implements `Synchronize`

> This is the header: `func (j JSONLHandler) Synchronize(f *IndexFile) error {`. 
> However, it would be nicer to have  `func (j JSONLHandler) Synchronize() error {` where

```go
type JSONLHandler struct{indexFile *IndexFile}
```

> But this would require a lot of refactoring, and I wanted to get your thoughts first. What I currently have fits nicer with the existing flow.


- Refactor tests