### PR TITLE
Wrote scripts + added a time flag [-t]

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	// index := flag.String("i", "", "Specify the existing index of the file to be opened, writing to stdout")
 	flag.Usage = func() {
-		fmt.Printf("Usage: %s [-i index] [-I index] [-t] filename\n", os.Args[0])
+		fmt.Printf("Usage: %s [-t] [-i index] [-I index] filename\n", os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(1)
 	}

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,18 +2,36 @@
 
 These examples are hosted on this repository's GitHub pages.
 
+
+```
+# yellow tripdata
+wget https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2023-01.parquet
+
+python3 -c "import pandas; pandas.read_parquet('yellow_tripdata_2023-01.parquet').to_json('yellow_tripdata_2023-01.jsonl', orient='records', lines=True)"
+```
+
 To build it locally, download the data and convert it to `jsonl`:
 
 ```sh
-wget https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2023-01.parquet
+cd workspace 
 
-python -c "import pandas; pandas.read_parquet('yellow_tripdata_2023-01.parquet').to_json('yellow_tripdata_2023-01.jsonl', orient='records', lines=True)"
+# green tripdata
+python3 -m pip install -r requirements.txt
+
+python3 fetch_data.py
 ```
 
 Then run the indexing process:
 
 ```sh
+npm run build-index
+```
 
+Copy the `.jsonl` and index file to `/client`
+
+```sh
+cp green_tripdata_2023-01.jsonl ../client
+cp green_tripdata_2023-01.jsonl.index ../client
 ```
 
 Build the AppendableDB client library:
@@ -22,4 +40,19 @@ Build the AppendableDB client library:
 npm run build
 ```
 
+Copy the Appendable library to `/client`
+
+```sh
+cp ../../dist/appendable.min.js ../client
+cp ../../dist/appendable.min.js.map ../client
+```
+
+
 Then run the development server:
+
+```sh
+npm run serve:example
+```
+
+
+You should see the example built on http://192.168.1.157:8080

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "esbuild src/index.ts --bundle --minify --sourcemap --outfile=dist/appendable.min.js",
-    "serve:example": "http-server"
+    "build-index": "go run cmd/main.go examples/workspace/green_tripdata_2023-01.jsonl",
+    "serve:example": "cd examples/client && npx http-server"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hey Kevin,

I saw in your `package.json` that you had the `http-server` dependency listed:
https://github.com/kevmo314/appendable/blob/ba36ad5524a48293173ba947f9de0970db317793/package.json#L23-L25

I assume this was for the [example readme](https://github.com/kevmo314/appendable/blob/main/examples/README.md). So I went in and filled out the remaining parts. 

This required me to write some scripts in `package.json`:
- `build-index`: builds the index file. (*this assumes you've properly loaded in `green_tripdata`*)
- `serve:example`: temporarily installs `http-server` and serves the content in `/client`

If you `cd` into `workspace/` and run the commands listed in the readme, you should be able to see a local version on http://192.168.1.157:8080/

--

On another note, I was shook when `yellow_tripdata` took almost a minute to generate an index file. This lead me to add some very simple timers to capture `NewIndexFile` and writing the index file. I was going to erase this but I figured you may interested so I added an optional `-t` flag to turn on this feature.

Here's what it looks like when you run `go run cmd/main.go -t <file>`:

`yellow_tripdata`: (.jsonl size: 1.22 GB)

<img width="847" alt="bruhthissolong" src="https://github.com/kevmo314/appendable/assets/38759997/fdbebd0a-743e-49fe-8515-60495050422e">

<br />

`green_tripdata`: (.jsonl size: 28.3 MB)

<img width="869" alt="noice" src="https://github.com/kevmo314/appendable/assets/38759997/91066f60-ca86-4d0e-8e58-d6c22c7b8227">


<br />
<br />

I can remove this if you don't find any use. Just thought it was interesting. No worries :)


