### PR TITLE
Protocol and Index_File

### DIFF
--- a/appendable-rs/Cargo.lock
+++ b/appendable-rs/Cargo.lock
@@ -5,6 +5,9 @@ version = 3
 [[package]]
 name = "appendable"
 version = "0.1.0"
+dependencies = [
+ "protocol",
+]
 
 [[package]]
 name = "btree"

--- a/appendable-rs/Cargo.lock
+++ b/appendable-rs/Cargo.lock
@@ -7,11 +7,31 @@ name = "appendable"
 version = "0.1.0"
 dependencies = [
  "protocol",
+ "tempfile",
+ "xxhash-rust",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "btree"
 version = "0.1.0"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cmd"
@@ -22,5 +42,140 @@ name = "encoding"
 version = "0.1.0"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "libc"
+version = "0.2.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+
+[[package]]
 name = "protocol"
 version = "0.1.0"
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"

--- a/appendable-rs/appendable/Cargo.toml
+++ b/appendable-rs/appendable/Cargo.toml
@@ -8,4 +8,8 @@ edition = "2021"
 [dependencies]
 protocol = { path="../protocol" }
 serde_json = "1.0.111"
-twox-hash = "1.6.3"
+xxhash-rust = { version = "0.8.8", features = ["xxh3"] }
+
+[dev-dependencies]
+tempfile = "3.9.0"
+

--- a/appendable-rs/appendable/Cargo.toml
+++ b/appendable-rs/appendable/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+protocol = { path="../protocol" }

--- a/appendable-rs/appendable/Cargo.toml
+++ b/appendable-rs/appendable/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 
 [dependencies]
 protocol = { path="../protocol" }
+serde_json = "1.0.111"
+twox-hash = "1.6.3"

--- a/appendable-rs/appendable/Cargo.toml
+++ b/appendable-rs/appendable/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 protocol = { path="../protocol" }
-serde_json = "1.0.111"
 xxhash-rust = { version = "0.8.8", features = ["xxh3"] }
 
 [dev-dependencies]

--- a/appendable-rs/appendable/mock_data.jsonl
+++ b/appendable-rs/appendable/mock_data.jsonl
@@ -1,0 +1,2 @@
+{"name": "matteo", "id": 2, "alpha": ["a", "b", "c"]}
+{"name": "kevin", "id": 1, "alpha": ["x", "y", "z"]}

--- a/appendable-rs/appendable/src/handler/jsonl_handler.rs
+++ b/appendable-rs/appendable/src/handler/jsonl_handler.rs
@@ -1,34 +1,25 @@
-use crate::index_file::{Index, IndexFile, IndexKey};
+use crate::index_file::Index;
 use crate::io::DataHandler;
 use serde_json::{Deserializer, Map, Value};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
-use twox_hash::xxh3::hash64;
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use xxhash_rust::xxh3::Xxh3;
 
 pub struct JSONLHandler {
-    pub file: File,
-    pub buffer: Option<Vec<u8>>,
+    reader: BufReader<File>,
+    xxh3: Xxh3,
 }
 impl JSONLHandler {
     pub fn new(file: File) -> Self {
-        JSONLHandler { file, buffer: None }
-    }
-
-    /// we need to read the entire file to buffer to compute byte slices for checksums
-    pub fn read_file_to_buffer(&mut self) -> Result<(), String> {
-        let mut buffer = Vec::new();
-        self.file
-            .read_to_end(&mut buffer)
-            .map_err(|e| e.to_string())?;
-
-        self.buffer = Some(buffer);
-
-        Ok(())
+        JSONLHandler {
+            reader: BufReader::new(file),
+            xxh3: Xxh3::new(),
+        }
     }
 }
 impl Seek for JSONLHandler {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-        self.file.seek(pos)
+        self.reader.seek(pos)
     }
 }
 impl DataHandler for JSONLHandler {
@@ -38,90 +29,43 @@ impl DataHandler for JSONLHandler {
         end_byte_offsets: &mut Vec<u64>,
         checksums: &mut Vec<u64>,
     ) -> Result<(), String> {
-        if self.buffer.is_none() {
-            self.read_file_to_buffer()?;
-        }
+        let mut line = String::new();
+        let mut start_offset: u64 = 0;
 
-        let buffer = self.buffer.as_ref().unwrap();
-
-        let mut deserializer = Deserializer::from_slice(buffer).into_iter::<Value>();
-
-        let mut start_offset = 0;
-
-        while let Some(result) = deserializer.next() {
-            let value = result.map_err(|e| e.to_string())?;
-            let end_offset = deserializer.byte_offset();
-
+        while self
+            .reader
+            .read_line(&mut line)
+            .map_err(|e| e.to_string())?
+            > 0
+        {
             let existing_count = end_byte_offsets.len();
+            // compute byte_offset for current line
+            let line_length = line.as_bytes().len() as u64;
+            let current_offset = start_offset + line_length + 1;
+            end_byte_offsets.push(current_offset);
 
-            // since the `StreamDeserializer` parses JSON values rather than lines, we don't have direct access to the original line strings
-            // this is a workaround where we find the byte slice from the start and end byte offset
-            let slice = &buffer[start_offset..end_offset];
-
-            let checksum = hash64(slice);
+            // compute checksum
+            self.xxh3.update(line.as_bytes());
+            let checksum = self.xxh3.digest(); // produce the final hash value
             checksums.push(checksum);
 
-            end_byte_offsets.push(end_offset as u64);
+            // Process the JSON line and update indexes
+            handle_json_object(&line, indexes, vec![], existing_count as u64, start_offset)?;
 
-
-            if let Value::Object(obj) = value {
-                handle_json_object(
-                    &obj,
-                    indexes,
-                    vec![],
-                    existing_count as u64,
-                    start_offset as u64,
-                )?;
-            } else {
-                return Err("expected a JSON object".to_string());
-            }
-
-            start_offset = end_offset;
-        };
+            start_offset = current_offset;
+            line.clear();
+        }
 
         Ok(())
     }
 }
 
 fn handle_json_object(
-    obj: &Map<String, Value>,
+    json_line: &str,
     indexes: &mut Vec<Index>,
     path: Vec<String>,
     data_index: u64,
     data_offset: u64,
 ) -> Result<(), String> {
-    for (key, value) in obj {
-        let field_offset = data_offset; // todo ask kevin about best way of incrementing this
-        let name = path
-            .iter()
-            .chain(std::iter::once(key))
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(".");
-
-        match value {
-            Value::String(s) => {
-                // Handle string value
-            }
-            Value::Number(n) => {
-                // Handle number value
-            }
-            Value::Bool(b) => {
-                // Handle boolean value
-            }
-            Value::Array(arr) => {
-                // Handle array - might involve recursion
-            }
-            Value::Object(nested_obj) => {
-                // Recursively handle nested object
-                handle_json_object(nested_obj, indexes, vec![name], data_index, field_offset)?;
-            }
-            Value::Null => {
-                // Handle null value
-            }
-            _ => return Err(format!("Unexpected type: {}", value)),
-        }
-    }
-
     Ok(())
 }

--- a/appendable-rs/appendable/src/handler/jsonl_handler.rs
+++ b/appendable-rs/appendable/src/handler/jsonl_handler.rs
@@ -1,0 +1,127 @@
+use crate::index_file::{Index, IndexFile, IndexKey};
+use crate::io::DataHandler;
+use serde_json::{Deserializer, Map, Value};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use twox_hash::xxh3::hash64;
+
+pub struct JSONLHandler {
+    pub file: File,
+    pub buffer: Option<Vec<u8>>,
+}
+impl JSONLHandler {
+    pub fn new(file: File) -> Self {
+        JSONLHandler { file, buffer: None }
+    }
+
+    /// we need to read the entire file to buffer to compute byte slices for checksums
+    pub fn read_file_to_buffer(&mut self) -> Result<(), String> {
+        let mut buffer = Vec::new();
+        self.file
+            .read_to_end(&mut buffer)
+            .map_err(|e| e.to_string())?;
+
+        self.buffer = Some(buffer);
+
+        Ok(())
+    }
+}
+impl Seek for JSONLHandler {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.file.seek(pos)
+    }
+}
+impl DataHandler for JSONLHandler {
+    fn synchronize(
+        &mut self,
+        indexes: &mut Vec<Index>,
+        end_byte_offsets: &mut Vec<u64>,
+        checksums: &mut Vec<u64>,
+    ) -> Result<(), String> {
+        if self.buffer.is_none() {
+            self.read_file_to_buffer()?;
+        }
+
+        let buffer = self.buffer.as_ref().unwrap();
+
+        let mut deserializer = Deserializer::from_slice(buffer).into_iter::<Value>();
+
+        let mut start_offset = 0;
+
+        while let Some(result) = deserializer.next() {
+            let value = result.map_err(|e| e.to_string())?;
+            let end_offset = deserializer.byte_offset();
+
+            let existing_count = end_byte_offsets.len();
+
+            // since the `StreamDeserializer` parses JSON values rather than lines, we don't have direct access to the original line strings
+            // this is a workaround where we find the byte slice from the start and end byte offset
+            let slice = &buffer[start_offset..end_offset];
+
+            let checksum = hash64(slice);
+            checksums.push(checksum);
+
+            end_byte_offsets.push(end_offset as u64);
+
+
+            if let Value::Object(obj) = value {
+                handle_json_object(
+                    &obj,
+                    indexes,
+                    vec![],
+                    existing_count as u64,
+                    start_offset as u64,
+                )?;
+            } else {
+                return Err("expected a JSON object".to_string());
+            }
+
+            start_offset = end_offset;
+        };
+
+        Ok(())
+    }
+}
+
+fn handle_json_object(
+    obj: &Map<String, Value>,
+    indexes: &mut Vec<Index>,
+    path: Vec<String>,
+    data_index: u64,
+    data_offset: u64,
+) -> Result<(), String> {
+    for (key, value) in obj {
+        let field_offset = data_offset; // todo ask kevin about best way of incrementing this
+        let name = path
+            .iter()
+            .chain(std::iter::once(key))
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(".");
+
+        match value {
+            Value::String(s) => {
+                // Handle string value
+            }
+            Value::Number(n) => {
+                // Handle number value
+            }
+            Value::Bool(b) => {
+                // Handle boolean value
+            }
+            Value::Array(arr) => {
+                // Handle array - might involve recursion
+            }
+            Value::Object(nested_obj) => {
+                // Recursively handle nested object
+                handle_json_object(nested_obj, indexes, vec![name], data_index, field_offset)?;
+            }
+            Value::Null => {
+                // Handle null value
+            }
+            _ => return Err(format!("Unexpected type: {}", value)),
+        }
+    }
+
+    Ok(())
+}

--- a/appendable-rs/appendable/src/index_file.rs
+++ b/appendable-rs/appendable/src/index_file.rs
@@ -94,6 +94,16 @@ impl IndexKey {
     }
 }
 
+impl fmt::Display for Index {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Field\nname: {}\n\ttype: {:?}\n\tindex_records: {:?}",
+            self.field_name, self.field_type, self.index_records
+        )
+    }
+}
+
 impl fmt::Display for IndexKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -121,6 +131,3 @@ impl fmt::Display for IndexKey {
         }
     }
 }
-
-// todo handleJSONLObject()
-// linking: https://github.com/kevmo314/appendable/blob/main/pkg/appendable/index_file.go#L77

--- a/appendable-rs/appendable/src/index_file.rs
+++ b/appendable-rs/appendable/src/index_file.rs
@@ -8,8 +8,8 @@ use std::fmt::Formatter;
 const CURRENT_VERSION: Version = 1;
 
 pub(crate) struct Index {
-    field_name: String,
-    field_type: FieldFlags,
+    pub(crate) field_name: String,
+    pub(crate) field_type: FieldFlags,
     pub(crate) index_records: HashMap<IndexKey, Vec<IndexRecord>>,
 }
 
@@ -19,7 +19,6 @@ pub struct IndexFile {
     pub(crate) indexes: Vec<Index>,
     pub(crate) end_byte_offsets: Vec<u64>,
     pub(crate) checksums: Vec<u64>,
-    data: Box<dyn DataHandler>,
     tail: u32,
 }
 
@@ -28,17 +27,12 @@ impl IndexFile {
         let mut file = IndexFile {
             version: CURRENT_VERSION,
             indexes: Vec::new(),
-            data: data_handler,
             end_byte_offsets: Vec::new(),
             checksums: Vec::new(),
             tail: 0,
         };
 
-        file.data.synchronize(
-            &mut file.indexes,
-            &mut file.end_byte_offsets,
-            &mut file.checksums,
-        )?;
+        data_handler.synchronize(&mut file)?;
 
         Ok(file)
     }

--- a/appendable-rs/appendable/src/index_file.rs
+++ b/appendable-rs/appendable/src/index_file.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::Formatter;
+use protocol::{Version, FieldType, IndexRecord};
+use protocol::field_type::FieldFlags;
+use crate::io::ReadSeek;
+
+const CURRENT_VERSION: u64 = 1;
+
+/// `IndexFile` is a representation of the entire index file.
+pub struct IndexFile {
+    version: Version,
+    indexes: Vec<Index>,
+    end_byte_offsets: Vec<u64>,
+    checksums: Vec<u64>,
+    data: Box<dyn ReadSeek>,
+    tail: u32,
+}
+
+impl IndexFile {
+    fn find_index(&mut self, name: &str, value: &IndexKey) -> usize {
+        if let Some((position, _)) = self.indexes
+            .iter()
+            .enumerate()
+            .find(|(_, index)| index.field_name == name) {
+
+            if !self.indexes[position].field_type.contains(value.field_type()) {
+                self.indexes[position].field_type.set(value.field_type());
+            }
+
+            position
+        } else {
+            let mut new_index = Index {
+                field_name: name.to_string(),
+                field_type: FieldFlags::new(),
+                index_records: HashMap::new(),
+            };
+
+            new_index.field_type.set(value.field_type());
+            self.indexes.push(new_index);
+            self.indexes.len() - 1
+        }
+    }
+}
+
+/// `IndexKey` addresses the dynamic typing of keys in `IndexRecord` by stating all possible variants
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub enum IndexKey {
+    String(String),
+    Number(String),
+    Boolean(bool),
+    Array(Vec<IndexKey>),
+    Object(HashMap<String, IndexKey>),
+}
+
+impl IndexKey {
+    fn field_type(&self) -> FieldType {
+        match self {
+            IndexKey::String(_) => FieldType::String,
+            IndexKey::Number(_) => FieldType::Number,
+            IndexKey::Boolean(_) => FieldType::Boolean,
+            IndexKey::Array(_) => FieldType::Array,
+            IndexKey::Object(_) => FieldType::Object
+        }
+    }
+}
+
+impl fmt::Display for IndexKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            IndexKey::String(s) => write!(f, "{}", s),
+            IndexKey::Number(n) => write!(f, "{}", n),
+            IndexKey::Boolean(b) => write!(f, "{}", b),
+            IndexKey::Array(v) => {
+                let elements = v.iter()
+                    .map(|element| format!("{}", element))
+                    .collect::<Vec<String>>()
+                    .join(", ");
+
+                write!(f, "[{}]", elements)
+            },
+            IndexKey::Object(o) => {
+                let entries = o.iter()
+                    .map(|(key, value)| format!("{}: {}", key, value))
+                    .collect::<Vec<String>>()
+                    .join(", ");
+
+                write!(f, "{{{}}}", entries)
+            }
+        }
+    }
+}
+
+struct Index {
+    field_name: String,
+    field_type: FieldFlags,
+    index_records: HashMap<IndexKey, Vec<IndexRecord>>
+}
+
+
+
+// todo handleJSONLObject()
+// linking: https://github.com/kevmo314/appendable/blob/main/pkg/appendable/index_file.go#L77

--- a/appendable-rs/appendable/src/io.rs
+++ b/appendable-rs/appendable/src/io.rs
@@ -1,0 +1,4 @@
+use std::io::{Read, Seek};
+
+pub trait ReadSeek: Read + Seek {}
+impl<T: Read + Seek + ?Sized> ReadSeek for T {}

--- a/appendable-rs/appendable/src/io.rs
+++ b/appendable-rs/appendable/src/io.rs
@@ -1,4 +1,11 @@
+use crate::index_file::Index;
 use std::io::{Read, Seek};
 
-pub trait ReadSeek: Read + Seek {}
-impl<T: Read + Seek + ?Sized> ReadSeek for T {}
+pub trait DataHandler: Seek {
+    fn synchronize(
+        &mut self,
+        indexes: &mut Vec<Index>,
+        end_byte_offsets: &mut Vec<u64>,
+        checksums: &mut Vec<u64>,
+    ) -> Result<(), String>;
+}

--- a/appendable-rs/appendable/src/io.rs
+++ b/appendable-rs/appendable/src/io.rs
@@ -1,11 +1,6 @@
-use crate::index_file::Index;
+use crate::index_file::{Index, IndexFile};
 use std::io::Seek;
 
 pub trait DataHandler: Seek {
-    fn synchronize(
-        &mut self,
-        indexes: &mut Vec<Index>,
-        end_byte_offsets: &mut Vec<u64>,
-        checksums: &mut Vec<u64>,
-    ) -> Result<(), String>;
+    fn synchronize(&mut self, index_file: &mut IndexFile) -> Result<(), String>;
 }

--- a/appendable-rs/appendable/src/io.rs
+++ b/appendable-rs/appendable/src/io.rs
@@ -1,5 +1,5 @@
 use crate::index_file::Index;
-use std::io::{Read, Seek};
+use std::io::Seek;
 
 pub trait DataHandler: Seek {
     fn synchronize(

--- a/appendable-rs/appendable/src/json_tokenizer.rs
+++ b/appendable-rs/appendable/src/json_tokenizer.rs
@@ -1,0 +1,87 @@
+pub enum Token {
+    OpenBracket,
+    CloseBracket,
+    Colon,
+    Comma,
+    String(String),
+    Number(String),
+    Boolean(bool),
+    OpenArray,
+    CloseArray,
+    Null,
+}
+
+pub struct JSONTokenizer {
+    input: Vec<u8>,
+    position: usize,
+}
+
+impl JSONTokenizer {
+    pub(crate) fn new(input: Vec<u8>) -> Self {
+        Self { input, position: 0 }
+    }
+
+    pub(crate) fn next(&mut self) -> Result<Option<(Token, usize)>, String> {
+        // edge case: check if we've reached the end of line
+        if self.position >= self.input.len() {
+            Ok(None)
+        } else {
+            let current_byte = self.input[self.position];
+
+            return match current_byte {
+                b'{' => {
+                    self.position += 1;
+                    Ok(Some((Token::OpenBracket, self.position - 1)))
+                }
+                b'}' => {
+                    self.position += 1;
+                    Ok(Some((Token::CloseBracket, self.position - 1)))
+                }
+                b'[' => {
+                    self.position += 1;
+                    Ok(Some((Token::OpenArray, self.position - 1)))
+                }
+                b']' => {
+                    self.position += 1;
+                    Ok(Some((Token::CloseArray, self.position - 1)))
+                }
+                b'\"' => {
+                    self.position += 1;
+                    self.tokenize_string()
+                }
+                b':' => {
+                    self.position += 1;
+                    Ok(Some((Token::Colon, self.position - 1)))
+                }
+                _ => Err(format!(
+                    "Unexpected character at position {}",
+                    self.position - 1
+                )),
+            };
+        }
+    }
+
+    fn tokenize_string(&mut self) -> Result<Option<(Token, usize)>, String> {
+        let start_position = self.position;
+
+        while self.position < self.input.len() {
+            let current_byte = self.input[start_position];
+
+            match current_byte {
+                b'\"' => {
+                    self.position += 1;
+                    Ok(Some((Token::String, start_position)))
+                }
+                b'\\' => {
+                    self.position += 2; // skip \n
+                    continue;
+                }
+                _ => {
+                    self.position += 1;
+                }
+            }
+        }
+
+        Err("Unterminated string".to_string())
+    }
+}

--- a/appendable-rs/appendable/src/lib.rs
+++ b/appendable-rs/appendable/src/lib.rs
@@ -1,14 +1,2 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod index_file;
+pub mod io;

--- a/appendable-rs/appendable/src/lib.rs
+++ b/appendable-rs/appendable/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod index_file;
 pub mod io;
+mod json_tokenizer;
 
 pub mod tests {
     pub mod jsonl_index_file;

--- a/appendable-rs/appendable/src/lib.rs
+++ b/appendable-rs/appendable/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod index_file;
 pub mod io;
 
+pub mod tests {
+    pub mod jsonl_index_file;
+}
+
 pub mod handler {
-    mod jsonl_handler;
+    pub mod jsonl_handler;
 }

--- a/appendable-rs/appendable/src/lib.rs
+++ b/appendable-rs/appendable/src/lib.rs
@@ -1,2 +1,6 @@
 pub mod index_file;
 pub mod io;
+
+pub mod handler {
+    mod jsonl_handler;
+}

--- a/appendable-rs/appendable/src/tests/jsonl_index_file.rs
+++ b/appendable-rs/appendable/src/tests/jsonl_index_file.rs
@@ -1,0 +1,39 @@
+#[cfg(test)]
+mod tests {
+    use crate::handler::jsonl_handler::JSONLHandler;
+    use crate::index_file::IndexFile;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::Path;
+    use tempfile::NamedTempFile;
+
+    fn mock_jsonl_file() -> std::io::Result<File> {
+        // Create a temporary file
+        let mut temp_file = NamedTempFile::new()?;
+
+        writeln!(
+            temp_file,
+            r#"{{"name": "matteo", "id": 2, "alpha": ["a", "b", "c"]}}"#
+        )?;
+        writeln!(
+            temp_file,
+            r#"{{"name": "kevin", "id": 1, "alpha": ["x", "y", "z"]}}"#
+        )?;
+
+        // Persist the file and return the File handle
+        let file = temp_file.persist(Path::new("mock_data.jsonl"))?;
+        Ok(file)
+    }
+
+    #[test]
+    fn create_index_file() {
+        let file = mock_jsonl_file().expect("Failed to create mock file");
+        let jsonl_handler = JSONLHandler::new(file);
+
+        let index_file = IndexFile::new(Box::new(jsonl_handler));
+
+        assert!(index_file.is_ok());
+
+        let index_file = index_file.unwrap();
+    }
+}

--- a/appendable-rs/protocol/src/field_type.rs
+++ b/appendable-rs/protocol/src/field_type.rs
@@ -1,4 +1,3 @@
-
 /// `FieldType` represents the type of data stored in the field, which follows JSON types excluding Object and null. Object is broken down into subfields and null is not stored.
 pub enum FieldType {
     String,
@@ -9,8 +8,8 @@ pub enum FieldType {
     Null,
 }
 
-
 /// `FieldFlags` is left as u64 to avoid shooting ourselves in the foot if we want to support more types in the future via other file formats
+#[derive(Debug)]
 pub struct FieldFlags {
     flags: u64,
 }
@@ -71,7 +70,7 @@ impl FieldFlags {
 
         match components.is_empty() {
             true => "unknown".to_string(),
-            false => components.join(" | ")
+            false => components.join(" | "),
         }
     }
 }

--- a/appendable-rs/protocol/src/field_type.rs
+++ b/appendable-rs/protocol/src/field_type.rs
@@ -1,0 +1,77 @@
+
+/// `FieldType` represents the type of data stored in the field, which follows JSON types excluding Object and null. Object is broken down into subfields and null is not stored.
+pub enum FieldType {
+    String,
+    Number,
+    Object,
+    Array,
+    Boolean,
+    Null,
+}
+
+
+/// `FieldFlags` is left as u64 to avoid shooting ourselves in the foot if we want to support more types in the future via other file formats
+pub struct FieldFlags {
+    flags: u64,
+}
+
+impl FieldFlags {
+    pub fn new() -> Self {
+        FieldFlags { flags: 0 }
+    }
+
+    pub fn set(&mut self, field: FieldType) {
+        match field {
+            FieldType::String => self.flags |= 1 << 0,
+            FieldType::Number => self.flags |= 1 << 1,
+            FieldType::Object => self.flags |= 1 << 2,
+            FieldType::Array => self.flags |= 1 << 3,
+            FieldType::Boolean => self.flags |= 1 << 4,
+            FieldType::Null => self.flags |= 1 << 5,
+        }
+    }
+
+    pub fn contains(&self, field: FieldType) -> bool {
+        match field {
+            FieldType::String => (self.flags & (1 << 0)) != 0,
+            FieldType::Number => (self.flags & (1 << 1)) != 0,
+            FieldType::Object => (self.flags & (1 << 2)) != 0,
+            FieldType::Array => (self.flags & (1 << 3)) != 0,
+            FieldType::Boolean => (self.flags & (1 << 4)) != 0,
+            FieldType::Null => (self.flags & (1 << 5)) != 0,
+        }
+    }
+
+    pub fn typescript_type(&self) -> String {
+        let mut components = Vec::new();
+
+        if self.contains(FieldType::String) {
+            components.push("string");
+        }
+
+        if self.contains(FieldType::Number) {
+            components.push("number");
+        }
+
+        if self.contains(FieldType::Object) {
+            components.push("Record");
+        }
+
+        if self.contains(FieldType::Array) {
+            components.push("any[]");
+        }
+
+        if self.contains(FieldType::Boolean) {
+            components.push("boolean");
+        }
+
+        if self.contains(FieldType::Null) {
+            components.push("null");
+        }
+
+        match components.is_empty() {
+            true => "unknown".to_string(),
+            false => components.join(" | ")
+        }
+    }
+}

--- a/appendable-rs/protocol/src/lib.rs
+++ b/appendable-rs/protocol/src/lib.rs
@@ -1,14 +1,13 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+pub mod field_type;
+pub mod protocol;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub use protocol::{
+    IndexFileHeader,
+    IndexHeader,
+    IndexRecord,
+    Version
+};
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub use field_type::{
+    FieldType
+};

--- a/appendable-rs/protocol/src/protocol.rs
+++ b/appendable-rs/protocol/src/protocol.rs
@@ -1,4 +1,5 @@
 use crate::field_type::FieldType;
+use std::fmt::{Debug, Display, Formatter};
 
 /*
 The overall index file for AppendableDB is structured as:
@@ -63,9 +64,24 @@ pub struct IndexHeader {
 /// - `field_start_byte_offset` represents the byte offset of the field in the data file to fetch exactly in the field value.
 /// - `field_length` is pessimistic: it is encoded value that is at least as long as the actual field value.
 pub struct IndexRecord {
-    data_number: u64,
-    field_start_byte_offset: u64,
-    field_length: u64,
+    pub data_number: u64,
+    pub field_start_byte_offset: u64,
+    pub field_length: u64,
+}
+
+impl Debug for IndexRecord {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+impl Display for IndexRecord {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "data_number: {}\nfield_start_byte_offset: {}\nfield_length: {}\n",
+            self.data_number, self.field_start_byte_offset, self.field_length
+        )
+    }
 }
 
 // Todo! write out JSON Token() implementation

--- a/appendable-rs/protocol/src/protocol.rs
+++ b/appendable-rs/protocol/src/protocol.rs
@@ -1,0 +1,72 @@
+use crate::field_type::FieldType;
+
+/*
+The overall index file for AppendableDB is structured as:
+
++-----------------------+
+| Version               |
++-----------------------+
+| IndexFileHeader       |
++-----------------------+
+| IndexHeader           |
++-----------------------+
+|        ...            |
++-----------------------+
+| IndexHeader           |
++-----------------------+
+| IndexRecord           |
++-----------------------+
+|        ...            |
++-----------------------+
+| IndexRecord           |
++-----------------------+
+| EndByteOffset         |
++-----------------------+
+|        ...            |
++-----------------------+
+| EndByteOffset         |
++-----------------------+
+| Checksum              |
++-----------------------+
+|        ...            |
++-----------------------+
+| Checksum              |
++-----------------------+
+*/
+
+/// `Version` is the version of AppendableDB this library is compatible with.
+pub type Version = u8;
+
+/// `IndexFileHeader` is the header of the index file.
+///
+/// # Attributes
+/// - `index_length` represents the number of bytes the `IndexHeader` occupy
+/// - `data_count` represents the number of data records indexed by this index file
+pub struct IndexFileHeader {
+    index_length: u64,
+    data_count: u64,
+}
+
+/// `IndexHeader` is the header of each index record. This represents the field available in the data file.
+///
+/// # Attributes
+/// - `field_type` represents the type of data stored in the field. Note that the field data doesn't need to follow this type, but it is used to determine the Typescript typings for the field.
+pub struct IndexHeader {
+    field_name: String,
+    field_type: FieldType,
+    index_record_count: u64,
+}
+
+/// `IndexRecord`
+///
+/// # Attributes
+/// - `field_start_byte_offset` represents the byte offset of the field in the data file to fetch exactly in the field value.
+/// - `field_length` is pessimistic: it is encoded value that is at least as long as the actual field value.
+pub struct IndexRecord {
+    data_number: u64,
+    field_start_byte_offset: u64,
+    field_length: u64,
+}
+
+// Todo! write out JSON Token() implementation
+// Linking: https://github.com/kevmo314/appendable/blob/main/pkg/protocol/protocol.go#L123


### PR DESCRIPTION
*Still a draft, I plan on committing frequently for transparency*

The first step was to translate `protocol`.

It should be fairly similar, with the only difference being a custom `FieldFlags` struct. `set()` uses bitwise operations to set flags corresponding to different `FieldType` values. 

`index_file.rs` should be fairly similar to the Go version, with the only difference being the `Index` struct takes `FieldFlag` as an attribute. 

Also, `IndexKey` is supposed to account for the `any` that you see in the Go version.