### PR TITLE
fix: remove truncate api

### DIFF
--- a/pkg/btree/multi.go
+++ b/pkg/btree/multi.go
@@ -105,6 +105,6 @@ func (m *LinkedMetaPage) Reset() error {
 	return nil
 }
 
-func NewMultiBPTree(t ReadWriteSeekTruncater) *LinkedMetaPage {
+func NewMultiBPTree(t io.ReadWriteSeeker) *LinkedMetaPage {
 	return &LinkedMetaPage{rws: t, offset: 0}
 }


### PR DESCRIPTION
Removing the truncate API for now since compaction isn't really a function of the B+ tree and we'll migrate it elsewhere.