### PR TITLE
fix: use the node byte size to determine splits

### DIFF
--- a/pkg/btree/bptree.go
+++ b/pkg/btree/bptree.go
@@ -145,7 +145,7 @@ func (t *BPTree) Insert(key ReferencedValue, value MemoryPointer) error {
 	for i := 0; i < len(path); i++ {
 		tr := path[i]
 		n := tr.node
-		if len(n.Keys) > t.tree.PageSize() {
+		if int(n.Size()) > t.tree.PageSize() {
 			// split the node
 			moffset, err := t.tree.NewPage()
 			if err != nil {
@@ -194,7 +194,8 @@ func (t *BPTree) Insert(key ReferencedValue, value MemoryPointer) error {
 				j, _ := p.node.bsearch(midKey.Value)
 				if j != p.index {
 					// j should be equal to p.index...?
-					// panic("aww")
+					// if this panic never happens then we can probably remove the above bsearch.
+					panic("this assumption apparently isn't true")
 				}
 				// insert the key into the parent
 				if j == len(p.node.Keys) {

--- a/pkg/btree/multi.go
+++ b/pkg/btree/multi.go
@@ -26,6 +26,10 @@ func (m *LinkedMetaPage) SetRoot(mp MemoryPointer) error {
 	return binary.Write(m.rws, binary.LittleEndian, mp)
 }
 
+func (m *LinkedMetaPage) BPTree() *BPTree {
+	return NewBPTree(m.rws, m)
+}
+
 func (m *LinkedMetaPage) Metadata() ([]byte, error) {
 	if _, err := m.rws.Seek(int64(m.offset)+24, io.SeekStart); err != nil {
 		return nil, err


### PR DESCRIPTION
This also improves performance by quite a bit since it avoids linear scans.