### PR TITLE
Split python script

### DIFF
--- a/.github/workflows/example-client.yml
+++ b/.github/workflows/example-client.yml
@@ -29,7 +29,7 @@ jobs:
           # Fetch the data in workspace
           cd examples/workspace
           python3 -m pip install -r requirements.txt
-          python3 fetch_data.py
+          python3 fetch_jsonl.py
           cd -
 
           # Build the index

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,8 @@ cd workspace
 # green tripdata
 python3 -m pip install -r requirements.txt
 
-python3 fetch_data.py
+# fetch data with .jsonl format
+python3 fetch_jsonl.py
 ```
 
 Then run the indexing process:

--- a/examples/workspace/fetch_csv.py
+++ b/examples/workspace/fetch_csv.py
@@ -7,7 +7,5 @@ import requests
 
 response = requests.get('https://d37ci6vzurychx.cloudfront.net/trip-data/green_tripdata_2023-01.parquet')
 
-pd.read_parquet(io.BytesIO(response.content)).to_json('green_tripdata_2023-01.jsonl', orient='records', lines=True)
-
 df = pd.read_parquet(io.BytesIO(response.content))
 df.to_csv('green_tripdata_2023-01.csv', index=False)

--- a/examples/workspace/fetch_jsonl.py
+++ b/examples/workspace/fetch_jsonl.py
@@ -1,0 +1,10 @@
+# Data taken from https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page
+
+import io
+
+import pandas as pd
+import requests
+
+response = requests.get('https://d37ci6vzurychx.cloudfront.net/trip-data/green_tripdata_2023-01.parquet')
+
+pd.read_parquet(io.BytesIO(response.content)).to_json('green_tripdata_2023-01.jsonl', orient='records', lines=True)


### PR DESCRIPTION
The github workflow calls `fetch_data.py` which retrieves the `jsonl` and `csv` formats for the data. To reduce overhead, I split the python scripts to `fetch_jsonl` and `fetch_csv`. 

This is simpler and nicer than creating some CLI that specifies which data to format in.

- [x] tested manually
- [x] updated workflow
- [x] updated readme 