### PR TITLE
fix: Retain correct type after appending

### DIFF
--- a/pkg/appendable/index_file_csv_test.go
+++ b/pkg/appendable/index_file_csv_test.go
@@ -169,6 +169,10 @@ func TestAppendDataRowCSV(t *testing.T) {
 				if keyType != "float64" {
 					t.Errorf("i keytype is %v", keyType)
 				}
+
+				if index.FieldType != protocol.FieldTypeNumber {
+					t.Errorf("index field type is not number. actual: %v", index.FieldType)
+				}
 			}
 		}
 
@@ -177,6 +181,10 @@ func TestAppendDataRowCSV(t *testing.T) {
 				keyType := reflect.TypeOf(key).String()
 				if keyType != "float64" {
 					t.Errorf("j keytype is %v", keyType)
+				}
+
+				if index.FieldType != protocol.FieldTypeNumber {
+					t.Errorf("index field type is not number. actual: %v", index.FieldType)
 				}
 			}
 		}


### PR DESCRIPTION
Suppose you had a column containing numbers, when you append data, the data got cast as a string. This PR refactors the code and retains the correct type throughout read index file.

Also, number values should always be cast as `float64`. In some cases, it was cast as an integer.

- [x] wrote tests to claim assertion