### PR TITLE
feat: chain queries

### DIFF
--- a/examples/client/editor.js
+++ b/examples/client/editor.js
@@ -1,0 +1,146 @@
+let activeEditor = "json";
+
+var editor = ace.edit("editor");
+editor.setTheme("ace/theme/chrome");
+
+var jsonSession = ace.createEditSession(
+	JSON.stringify(
+		{
+			where: [
+				{
+					operation: ">=",
+					key: "trip_distance",
+					value: 10,
+				},
+			],
+			orderBy: [
+				{
+					key: "trip_distance",
+					direction: "ASC",
+				},
+			],
+			select: [
+				"VendorID",
+				"trip_distance",
+				"passenger_count",
+				"fare_amount",
+				"tip_amount",
+				"mta_tax",
+			],
+		},
+		null,
+		2
+	),
+	"ace/mode/json"
+);
+
+var jsCode =
+	"db\n" +
+	"  .where('trip_distance', '>=', 10)\n" +
+	"  .orderBy('trip_distance', 'ASC')\n" +
+	"  .select([\n" +
+	"      'VendorID',\n" +
+	"      'trip_distance',\n" +
+	"      'passenger_count',\n" +
+	"      'fare_amount',\n" +
+	"      'tip_amount',\n" +
+	"      'mta_tax'\n" +
+	"  ])\n" +
+	"  .get();";
+
+var jsSession = ace.createEditSession(jsCode, "ace/mode/javascript");
+
+editor.setSession(jsonSession);
+
+var jsonTab = document.getElementById("jsonTab");
+var jsTab = document.getElementById("jsTab");
+
+jsonTab.addEventListener("click", function () {
+	editor.setSession(jsonSession);
+	attachJsonEditorUX();
+	activeEditor = "json";
+	window.activeEditor = activeEditor;
+});
+
+jsTab.addEventListener("click", function () {
+	editor.setSession(jsSession);
+	activeEditor = "javascript";
+	window.activeEditor = activeEditor;
+});
+
+function attachJsonEditorUX() {
+	// NOTE: when composite indexes get supported, remove this UX feature
+	// <---- start of UX feature ---->
+	let isProgramChange = false;
+	let lastEdited = "none";
+	let prevWhereKey = "trip_distance";
+	let prevOrderByKey = "trip_distance";
+
+	function updateKey(editorContent) {
+		try {
+			let query = JSON.parse(editorContent);
+			if (query.where && query.orderBy) {
+				const whereKey = query.where[0].key;
+				const orderByKey = query.orderBy[0].key;
+
+				if (lastEdited === "where") {
+					query.orderBy[0].key = whereKey;
+				} else if (lastEdited === "orderBy") {
+					query.where[0].key = orderByKey;
+				}
+
+				prevWhereKey = whereKey;
+				prevOrderByKey = orderByKey;
+
+				return JSON.stringify(query, null, 2);
+			}
+		} catch (e) {
+			console.log("Error parsing JSON:", e.message);
+			console.log("Incomplete string content:", editorContent);
+		}
+		return editorContent;
+	}
+
+	editor.getSession().on("change", function (e) {
+		if (isProgramChange) {
+			isProgramChange = false;
+			return;
+		}
+
+		const cursorPosition = editor.getCursorPosition();
+		const editorContent = editor.getSession().getValue();
+
+		let query;
+		try {
+			query = JSON.parse(editorContent);
+		} catch (e) {
+			return;
+		}
+
+		const currentWhereKey = query.where ? query.where[0].key : "";
+		const currentOrderByKey = query.orderBy ? query.orderBy[0].key : "";
+
+		if (currentWhereKey !== prevWhereKey) {
+			lastEdited = "where";
+		} else if (currentOrderByKey !== prevOrderByKey) {
+			lastEdited = "orderBy";
+		}
+
+		const updatedContent = updateKey(editorContent);
+
+		if (updatedContent !== editorContent) {
+			isProgramChange = true;
+
+			const doc = editor.getSession().getDocument();
+			doc.setValue(updatedContent);
+
+			editor.moveCursorToPosition(cursorPosition);
+			editor.clearSelection();
+		}
+	});
+
+	// <---- end of UX feature ---->
+}
+
+attachJsonEditorUX();
+window.activeEditor = activeEditor;

--- a/examples/client/index.html
+++ b/examples/client/index.html
@@ -6,6 +6,7 @@
 			type="text/javascript"
 			charset="utf-8"
 		></script>
+		<link rel="stylesheet" href="styles.css" />
 		<script src="appendable.min.js"></script>
 		<script>
 			Appendable.init(
@@ -14,7 +15,6 @@
 				Appendable.FormatType.Csv
 			).then(async (db) => {
 				let dbFields = [];
-				let queryHeaders = [];
 
 				// populate fields
 				db.fields().then((fields) => {
@@ -37,27 +37,59 @@
 
 				// then execute the query
 				document.getElementById("execute").onclick = async () => {
+					document.getElementById("results-header").innerHTML = "";
 					document.getElementById("results").innerHTML = "";
-					const queryJson = JSON.parse(editor.getValue());
 
-					try {
-						const query = await db.query(queryJson);
-						let queryHeaders = queryJson.select ?? dbFields;
-						await bindQuery(query, queryHeaders);
-					} catch (error) {
-						console.log("error: ", error);
-						document.getElementById("results-header").innerHTML = "";
-						document.getElementById("results").innerHTML = error.message;
+					const editorContent = editor.getValue();
+
+					if (window.activeEditor === "json") {
+						const queryJson = JSON.parse(editorContent);
+						try {
+							const query = await db.query(queryJson);
+							let queryHeaders = queryJson.select ?? dbFields;
+							await bindQuery(query, queryHeaders);
+						} catch (error) {
+							console.log("error: ", error);
+							document.getElementById("results-header").innerHTML = "";
+							document.getElementById("results").innerHTML = error.message;
+						}
+					} else if (window.activeEditor === "javascript") {
+						function extractSelect(content) {
+							const selectRegex = /\.select\(\s*\[([^\]]*)\]\s*\)/;
+							const match = content.match(selectRegex);
+
+							if (match && match[1]) {
+								const headersContent = match[1].trim();
+								const headers = headersContent
+									.split(",")
+									.map((e) => e.trim().replace(/['"`]/g, ""));
+
+								return headers;
+							}
+
+							return null;
+						}
+
+						try {
+							const query = await eval(editorContent);
+
+							const queryHeaders = extractSelect(editorContent) ?? dbFields;
+
+							if (query) {
+								await bindQuery(query, queryHeaders);
+							}
+						} catch (error) {
+							console.log("error: ", error);
+							document.getElementById("results-header").innerHTML = "";
+							document.getElementById("results").innerHTML = error.message;
+						}
 					}
 				};
 
-				document.getElementById("results").innerHTML = "";
-
 				const queryJson = JSON.parse(editor.getValue());
-				queryHeaders = queryJson.select ?? dbFields;
+				const query = await db.query(JSON.parse(editor.getValue()));
 
-				const query = db.query(JSON.parse(editor.getValue()));
-				await bindQuery(query, queryHeaders);
+				await bindQuery(query, queryJson.select);
 			});
 
 			async function bindQuery(query, headers) {
@@ -113,48 +145,6 @@
 				}
 			}
 		</script>
-		<style>
-			body,
-			html {
-				margin: 0;
-				padding: 0px 0px 4px 4px;
-			}
-			.flex-1 {
-				flex: 1;
-				display: flex;
-				gap: 0 30px;
-				height: 100vh;
-				width: 100vw;
-			}
-			.result-row {
-				cursor: pointer;
-			}
-			.result-row:hover {
-				background-color: yellow;
-			}
-			#fields {
-				max-height: calc(100vh - 50px);
-				overflow-y: auto;
-			}
-			#results {
-				overflow-y: auto;
-				max-height: calc(100vh - 670px);
-			}
-			#results-header {
-				width: max-content;
-			}
-
-			.header-item,
-			.result-cell {
-				padding: 4px;
-				text-align: left;
-				min-width: 200px;
-			}
-			.header-item {
-				background-color: #f0f0f0;
-				font-weight: bold;
-			}
-		</style>
 	</head>
 	<body>
 		<div>
@@ -188,12 +178,14 @@
 			</div>
 			<div>
 				<h2>Query</h2>
-				<button id="execute">Execute</button>
-				<div
-					id="json-editor"
-					style="height: 400px; width: 600px; margin-top: 40px"
-				></div>
+				<div>
+					<button id="jsonTab">json</button>
+					<button id="jsTab">javascript</button>
+					<div id="editor" style="height: 400px; width: 628px"></div>
+				</div>
 				<h2>Results</h2>
+
+				<button id="execute">Execute</button>
 				<button id="next">Fetch more</button>
 				<div>
 					<pre id="results-header"></pre>
@@ -201,115 +193,6 @@
 				</div>
 			</div>
 		</div>
-		<script>
-			var editor = ace.edit("json-editor");
-			editor.session.setMode("ace/mode/json");
-			editor.setTheme("ace/theme/chrome");
-			editor.getSession().setTabSize(2);
-			editor.getSession().setUseSoftTabs(true);
-
-			// NOTE: when composite indexes get supported, remove this UX feature
-			// <---- start of UX feature ---->
-			let isProgramChange = false;
-			let lastEdited = "none";
-			let prevWhereKey = "trip_distance";
-			let prevOrderByKey = "trip_distance";
-
-			function updateKey(editorContent) {
-				try {
-					let query = JSON.parse(editorContent);
-					if (query.where && query.orderBy) {
-						const whereKey = query.where[0].key;
-						const orderByKey = query.orderBy[0].key;
-
-						if (lastEdited === "where") {
-							query.orderBy[0].key = whereKey;
-						} else if (lastEdited === "orderBy") {
-							query.where[0].key = orderByKey;
-						}
-
-						prevWhereKey = whereKey;
-						prevOrderByKey = orderByKey;
-
-						return JSON.stringify(query, null, 2);
-					}
-				} catch (e) {
-					console.log("Error parsing JSON:", e.message);
-					console.log("Incomplete string content:", editorContent);
-				}
-				return editorContent;
-			}
-
-			editor.getSession().on("change", function (e) {
-				if (isProgramChange) {
-					isProgramChange = false;
-					return;
-				}
-
-				const cursorPosition = editor.getCursorPosition();
-				const editorContent = editor.getSession().getValue();
-
-				let query;
-				try {
-					query = JSON.parse(editorContent);
-				} catch (e) {
-					return;
-				}
-
-				const currentWhereKey = query.where ? query.where[0].key : "";
-				const currentOrderByKey = query.orderBy ? query.orderBy[0].key : "";
-
-				if (currentWhereKey !== prevWhereKey) {
-					lastEdited = "where";
-				} else if (currentOrderByKey !== prevOrderByKey) {
-					lastEdited = "orderBy";
-				}
-
-				const updatedContent = updateKey(editorContent);
-
-				if (updatedContent !== editorContent) {
-					isProgramChange = true;
-
-					const doc = editor.getSession().getDocument();
-					doc.setValue(updatedContent);
-
-					editor.moveCursorToPosition(cursorPosition);
-					editor.clearSelection();
-				}
-			});
-
-			// <---- end of UX feature ---->
-
-			editor.setValue(
-				JSON.stringify(
-					{
-						where: [
-							{
-								operation: ">=",
-								key: "trip_distance",
-								value: 10,
-							},
-						],
-						orderBy: [
-							{
-								key: "trip_distance",
-								direction: "ASC",
-							},
-						],
-						select: [
-							"VendorID",
-							"trip_distance",
-							"passenger_count",
-							"fare_amount",
-							"tip_amount",
-							"mta_tax",
-						],
-					},
-					null,
-					2
-				),
-				-1
-			);
-		</script>
+		<script src="editor.js"></script>
 	</body>
 </html>

--- a/examples/client/styles.css
+++ b/examples/client/styles.css
@@ -1,0 +1,39 @@
+body,
+html {
+	margin: 0;
+	padding: 0px 0px 4px 4px;
+}
+.flex-1 {
+	flex: 1;
+	display: flex;
+	gap: 0 30px;
+	height: 100vh;
+	width: 100vw;
+}
+.result-row {
+	cursor: pointer;
+}
+.result-row:hover {
+	background-color: yellow;
+}
+#fields {
+	max-height: calc(100vh - 50px);
+	overflow-y: auto;
+}
+#results {
+	overflow-y: auto;
+	max-height: calc(100vh - 670px);
+}
+#results-header {
+	width: max-content;
+}
+.header-item,
+.result-cell {
+	padding: 4px;
+	text-align: left;
+	min-width: 200px;
+}
+.header-item {
+	background-color: #f0f0f0;
+	font-weight: bold;
+}

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1,6 +1,7 @@
 import { FormatType } from "..";
 import { DataFile } from "../data-file";
 import { IndexFile, VersionedIndexFile } from "../index-file";
+import { QueryBuilder } from "./query-builder";
 import { validateQuery } from "./query-validation";
 
 export type Schema = {
@@ -24,6 +25,7 @@ export type Query<T extends Schema> = {
 	where?: WhereNode<T>[];
 	orderBy?: OrderBy<T>[];
 	select?: SelectField<T>[];
+	limit?: number;
 };
 
 export enum FieldType {
@@ -293,5 +295,13 @@ export class Database<T extends Schema> {
 				yield dataFieldValue;
 			}
 		}
+	}
+
+	where(
+		key: keyof T,
+		operation: WhereNode<T>["operation"],
+		value: T[keyof T]
+	): QueryBuilder<T> {
+		return new QueryBuilder(this).where(key, operation, value);
 	}
 }

--- a/src/db/query-builder.ts
+++ b/src/db/query-builder.ts
@@ -1,0 +1,84 @@
+import { Database, OrderBy, Query, Schema, WhereNode } from "./database";
+
+/**
+ * A class for building and executing database queries in a flexible API style.
+ * Allows chaining methods for 'where', 'orderBy', 'select', and 'limit' clauses.
+ */
+export class QueryBuilder<T extends Schema> {
+	private queryObject: Query<T> = {
+		where: [],
+		orderBy: undefined,
+		select: undefined,
+		limit: undefined,
+	};
+
+	/**
+	 * Initializes a new instance of the QueryBuilder class.
+	 * @param {Database<T>} database - An Appendable database instance to execute queries against.
+	 */
+	constructor(private database: Database<T>) {}
+
+	/**
+	 * Executes the constructed query and returns an asychronous generator.
+	 * @yields {Promise<IteratorResult<T, any>>} Query result.
+	 */
+	async *get() {
+		for await (const item of this.database.query(this.queryObject)) {
+			yield item;
+		}
+	}
+
+	/**
+	 * Adds a 'where' clause to the query.
+	 *
+	 * @param {keyof T} key - The index header's field name to apply the 'where' condition.
+	 * @param {WhereNode<T>["operation"]} operation - The comparison relation (e.g., >=, <=, ==, >=, >).
+	 * @param {T[keyof T]} value - The value to compare against.
+	 * @returns {QueryBuilder<T>} The QueryBuilder instance.
+	 */
+	where(
+		key: keyof T,
+		operation: WhereNode<T>["operation"],
+		value: T[keyof T]
+	): QueryBuilder<T> {
+		this.queryObject.where?.push({ key, operation, value });
+		return this;
+	}
+
+	/**
+	 * Adds an 'orderBy' clause to the query.
+	 *
+	 * @param {keyof T} key - The index header's field name to order by.
+	 * @param {OrderBy<T>["direction"]} direction - The sorting direction (e.g., ASC, DESC).
+	 * @returns {QueryBuilder<T>} The QueryBuilder instance.
+	 */
+	orderBy(key: keyof T, direction: OrderBy<T>["direction"]): QueryBuilder<T> {
+		this.queryObject.orderBy
+			? this.queryObject.orderBy.push({ key, direction })
+			: (this.queryObject.orderBy = [{ key, direction }]);
+
+		return this;
+	}
+
+	/**
+	 * Specifies the fields to be selected in the query.
+	 *
+	 * @param {(keyof T)[]} keys - A list of index header field names.
+	 * @returns {QueryBuilder<T>} The QueryBuilder instance.
+	 */
+	select(keys: (keyof T)[]): QueryBuilder<T> {
+		this.queryObject.select = keys;
+		return this;
+	}
+
+	/**
+	 * Limits the number of records returned by the query.
+	 *
+	 * @param {number} limit - The maximum number of records to return.
+	 * @returns {QueryBuilder<T>} The QueryBuilder instance.
+	 */
+	limit(limit: number): QueryBuilder<T> {
+		this.queryObject.limit = limit;
+		return this;
+	}
+}

--- a/src/db/query-builder.ts
+++ b/src/db/query-builder.ts
@@ -19,13 +19,10 @@ export class QueryBuilder<T extends Schema> {
 	constructor(private database: Database<T>) {}
 
 	/**
-	 * Executes the constructed query and returns an asychronous generator.
-	 * @yields {Promise<IteratorResult<T, any>>} Query result.
+	 * Executes the constructed query
 	 */
-	async *get() {
-		for await (const item of this.database.query(this.queryObject)) {
-			yield item;
-		}
+	get() {
+		return this.database.query(this.queryObject);
 	}
 
 	/**

--- a/src/db/query-validation.ts
+++ b/src/db/query-validation.ts
@@ -35,6 +35,8 @@ function validateWhere<T extends Schema>(
 		throw new Error("Missing 'where' clause.");
 	}
 
+	console.log("validating where: ", where);
+
 	for (const whereNode of where) {
 		if (!["<", "<=", "==", ">=", ">"].includes(whereNode.operation)) {
 			throw new Error("Invalid operation in 'where' clause.");
@@ -114,6 +116,7 @@ function validateOrderBy<T extends Schema>(
 	whereKey: string
 ): void {
 	if (orderBy) {
+		console.log("validating orderBy: ", orderBy);
 		if (!Array.isArray(orderBy) || orderBy.length === 0) {
 			throw new Error("Invalid 'orderBy' clause.");
 		}
@@ -143,8 +146,9 @@ function validateSelect<T extends Schema>(
 	headers: Header[]
 ): void {
 	if (select) {
+		console.log("validating select: ", select);
 		if (!Array.isArray(select) || select.length === 0) {
-			throw new Error("Invalid 'selectFields' clause");
+			throw new Error("Invalid 'select' clause");
 		}
 
 		for (const field of select) {
@@ -152,7 +156,7 @@ function validateSelect<T extends Schema>(
 
 			if (!header) {
 				throw new Error(
-					`'key': ${field as string} in 'selectFields' clause does not exist in dataset.`
+					`'key': ${field as string} in 'select' clause does not exist in dataset.`
 				);
 			}
 		}

--- a/src/index-file.ts
+++ b/src/index-file.ts
@@ -140,7 +140,6 @@ class IndexFileV1<T> implements VersionedIndexFile<T> {
 			throw new Error("offset out of range");
 		}
 		const headers = await this.indexHeaders();
-		console.log("headers: ", headers);
 		const headerIndex = headers.findIndex(
 			(header) => header.fieldName === field
 		);


### PR DESCRIPTION
## Query Chaining
Query chaining is more fluent and flexible in its query style. 

You can now write queries:
> ```typescript
> const query = await db
>   .where('trip_distance', '>=', 10)
>   .orderBy('trip_distance', 'ASC')
>   .select([
>       'VendorID',
>       'trip_distance',
>       'passenger_count',
>       'fare_amount',
>       'tip_amount',
>       'mta_tax'
>   ])
>   .get();
> ```

It's forkable, so you can write derived queries:
> ```typescript
> const query = await db.where("...");
> const derivedQuery = query.orderBy("...");
>```

This PR also introduces a JS editor to the demo. The editor can now toggle between JSON and JS. Depending on the editor, you can build a query in JSON form or through the chaining of clauses.


Since the demo's gotten a lot more features, I also separated the `.css` and the editor-related logic to its own files.