### PR TITLE
Fix stale demo link

### DIFF
--- a/examples/client/index.html
+++ b/examples/client/index.html
@@ -76,7 +76,6 @@
                 <button id="jsonTab">json</button>
                 <button id="jsTab">javascript</button>
                 <div id="editor" style="height: 400px; width: 628px"></div>
-                <button id="execute">Execute</button>
                 <h2>Results</h2>
                 <button id="execute">Execute</button>
                 <button id="next">Fetch more</button>

--- a/examples/client/index.html
+++ b/examples/client/index.html
@@ -51,7 +51,7 @@
         <div>
             Download the raw data here:
             <a href="green_tripdata_2023-01.jsonl">JSONL</a> -
-            <a href="green_tripdata_2023-01.jsonl.index">Appendable Index</a> -
+            <a href="green_tripdata_2023-01.index">Appendable Index</a> -
             <a href="https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page">Source</a>
         </div>
         <p>


### PR DESCRIPTION
Currently, the demo links to an invalid `.index` file. This PR fixes that