### PR TITLE
feat: prevent execute misfires

### DIFF
--- a/examples/client/index.html
+++ b/examples/client/index.html
@@ -117,30 +117,21 @@
 
                     const editorContent = editor.getValue();
 
-                    if (window.activeEditor === "json") {
-                        try {
+                    try {
+                        if (window.activeEditor === "json") {
                             const queryJson = JSON.parse(editorContent);
-
                             const fields = await db.fields();
                             Appendable.validateQuery(queryJson, fields)
-
                             const query = await db.query(queryJson);
                             await bindQuery(query);
-
-                        } catch (error) {
-                            console.log("error: ", error);
-                            document.getElementById("results").innerHTML = error.message;
-                            executeButton.disabled = false;
-                        }
-                    } else if (window.activeEditor === "javascript") {
-                        try {
+                        } else if (window.activeEditor === "javascript") {
                             const query = await eval(editorContent);
                             await bindQuery(query);
-                        } catch (error) {
-                            console.log("error: ", error);
-                            document.getElementById("results").innerHTML = error.message;
-                            executeButton.disabled = false;
                         }
+                    } catch (error) {
+                        console.log("error: ", error);
+                        document.getElementById("results").innerHTML = error.message;
+                        executeButton.disabled = false;
                     }
                 };
 

--- a/examples/client/index.html
+++ b/examples/client/index.html
@@ -112,42 +112,52 @@
                 // then execute the query
                 document.getElementById("execute").onclick = async () => {
                     document.getElementById("results").innerHTML = "";
+                    const executeButton = document.getElementById("execute");
+                    executeButton.disabled = true;
 
                     const editorContent = editor.getValue();
 
                     if (window.activeEditor === "json") {
-                        console.log("window is in json")
-
-                        const queryJson = JSON.parse(editor.getValue());
-
                         try {
-                            const fields = await db.fields();
-                            Appendable.validateQuery(queryJson, fields)
+                            const queryJson = JSON.parse(editorContent);
 
-                            const query = await db.query(queryJson);
-                            await bindQuery(query);
-                        } catch (error) {
-                            console.log("error: ", error);
-                            document.getElementById("results").innerHTML = error.message;
-                        }
-                    } else if (window.activeEditor === "javascript") {
-                        console.log("window is in javascript");
-                        try {
-                            const query = await eval(editorContent);
+                            try {
+                                const fields = await db.fields();
+                                Appendable.validateQuery(queryJson, fields)
 
-                            if (query) {
+                                const query = await db.query(queryJson);
                                 await bindQuery(query);
+                            } catch (error) {
+                                console.log("error: ", error);
+                                document.getElementById("results").innerHTML = error.message;
+                                executeButton.disabled = false;
                             }
                         } catch (error) {
                             console.log("error: ", error);
                             document.getElementById("results").innerHTML = error.message;
+                            executeButton.disabled = false;
+                        }
+                    } else if (window.activeEditor === "javascript") {
+                        try {
+                            const query = await eval(editorContent);
+                            await bindQuery(query);
+                        } catch (error) {
+                            console.log("error: ", error);
+                            document.getElementById("results").innerHTML = error.message;
+                            executeButton.disabled = false;
                         }
                     }
                 };
 
                 document.getElementById("results").innerHTML = "";
-                const query = await db.query(JSON.parse(editor.getValue()));
-                await bindQuery(query);
+
+                try {
+                    const query = await db.query(JSON.parse(editor.getValue()));
+                    await bindQuery(query);
+                } catch (error) {
+                    document.getElementById("results").innerHTML = error.message;
+                    executeButton.disabled = false;
+                }
             });
 
             async function bindQuery(query) {
@@ -169,6 +179,7 @@
                 for (let i = 0; i < 10; i++) {
                     await appendResult();
                 }
+                document.getElementById("execute").disabled = false;
                 while (true) {
                     document.getElementById("next").disabled = false;
                     await new Promise(

--- a/examples/client/index.html
+++ b/examples/client/index.html
@@ -121,17 +121,12 @@
                         try {
                             const queryJson = JSON.parse(editorContent);
 
-                            try {
-                                const fields = await db.fields();
-                                Appendable.validateQuery(queryJson, fields)
+                            const fields = await db.fields();
+                            Appendable.validateQuery(queryJson, fields)
 
-                                const query = await db.query(queryJson);
-                                await bindQuery(query);
-                            } catch (error) {
-                                console.log("error: ", error);
-                                document.getElementById("results").innerHTML = error.message;
-                                executeButton.disabled = false;
-                            }
+                            const query = await db.query(queryJson);
+                            await bindQuery(query);
+
                         } catch (error) {
                             console.log("error: ", error);
                             document.getElementById("results").innerHTML = error.message;


### PR DESCRIPTION
Closes #134 

Upon clicking the `execute` button, this PR disables the button until the query has been fetched. This fixes the misfires that happen when you spam the `execute` button.

