### PR TITLE
feat: Skiplist data structure to expedite meta page searching

### DIFF
--- a/src/index-file/skiplist.ts
+++ b/src/index-file/skiplist.ts
@@ -102,4 +102,8 @@ export class SkipList {
       `metapage not found for ${query.fieldName} and ${query.fieldType}`,
     );
   }
+
+  getSentinel(): SkipListNode {
+    return this.head;
+  }
 }

--- a/src/index-file/skiplist.ts
+++ b/src/index-file/skiplist.ts
@@ -1,0 +1,105 @@
+import { LinkedMetaPage } from "../btree/multi";
+import { FieldType } from "../db/database";
+import { IndexMeta, readIndexMeta } from "./meta";
+
+interface SkipListNode {
+  fieldName: string; // fieldName and fieldType form a composite key
+  fieldType: FieldType;
+  mp: LinkedMetaPage | null;
+  next: Array<SkipListNode | null>;
+}
+
+export class SkipList {
+  private head: SkipListNode;
+  private maxLevel: number;
+
+  constructor(maxLevel?: number) {
+    this.maxLevel = maxLevel ? maxLevel : 16;
+    this.head = {
+      fieldName: "",
+      fieldType: FieldType.String, // since this value is 0
+      mp: null,
+      next: new Array(this.maxLevel).fill(null),
+    };
+  }
+
+  private coinFlip(): number {
+    const p = 0.5; // the probability factor
+    let level = 1;
+    while (Math.random() < p && level < this.maxLevel) {
+      level++;
+    }
+    return level;
+  }
+
+  async insert(mpIndexMeta: IndexMeta, mp: LinkedMetaPage): Promise<void> {
+    const newNodeLevel = this.coinFlip();
+
+    let updatePath: (SkipListNode | null)[] = new Array(this.maxLevel).fill(
+      null,
+    );
+
+    let currNode = this.head;
+
+    for (let idx = this.maxLevel - 1; idx >= 0; idx--) {
+      while (
+        currNode.next[idx] !== null &&
+        (currNode.next[idx]!.fieldName < mpIndexMeta.fieldName ||
+          (currNode.next[idx]!.fieldName === mpIndexMeta.fieldName &&
+            currNode.next[idx]!.fieldType < mpIndexMeta.fieldType))
+      ) {
+        currNode = currNode.next[idx]!;
+      }
+      updatePath[idx] = currNode;
+    }
+
+    const newNode: SkipListNode = {
+      fieldName: mpIndexMeta.fieldName,
+      fieldType: mpIndexMeta.fieldType,
+      mp: mp,
+      next: new Array(newNodeLevel).fill(null),
+    };
+
+    for (let idx = 0; idx <= newNodeLevel - 1; idx++) {
+      if (updatePath[idx]) {
+        newNode.next[idx] = updatePath[idx]!.next[idx];
+        updatePath[idx]!.next[idx] = newNode;
+      }
+    }
+  }
+
+  async search(query: IndexMeta): Promise<LinkedMetaPage> {
+    let currNode = this.head;
+    let count = 0;
+
+    for (let level = this.maxLevel - 1; level >= 0; level--) {
+      while (currNode.next[level] !== null) {
+        if (
+          currNode.next[level]!.fieldName === query.fieldName &&
+          currNode.next[level]!.fieldType === query.fieldType
+        ) {
+          const mp = currNode.next[level]!.mp;
+          if (!mp) {
+            throw new Error(`metapage found is null`);
+          }
+          console.log("it took count :", count);
+          return mp;
+        } else if (
+          currNode.next[level]!.fieldName < query.fieldName ||
+          (currNode.next[level]!.fieldName === query.fieldName &&
+            currNode.next[level]!.fieldType < query.fieldType)
+        ) {
+          currNode = currNode.next[level]!;
+        } else {
+          break;
+        }
+
+        count += 1;
+      }
+    }
+
+    throw new Error(
+      `metapage not found for ${query.fieldName} and ${query.fieldType}`,
+    );
+  }
+}

--- a/src/tests/multi.test.ts
+++ b/src/tests/multi.test.ts
@@ -1,9 +1,7 @@
 import { LengthIntegrityError, RangeResolver } from "../resolver";
 import { PageFile } from "../btree/pagefile";
-import { ReadMultiBPTree } from "../btree/multi";
+import { ReadMultiBPTree, maxUint64 } from "../btree/multi";
 import { arrayBufferToString, readBinaryFile } from "./test-util";
-
-const maxUint64 = 2n ** 64n - 1n;
 
 describe("test metadata", () => {
   let mockMetadata: Uint8Array;

--- a/src/tests/skiplist.test.ts
+++ b/src/tests/skiplist.test.ts
@@ -1,0 +1,119 @@
+import { LinkedMetaPage } from "../btree/multi";
+import { FieldType } from "../db/database";
+import { IndexMeta } from "../index-file/meta";
+import { SkipList } from "../index-file/skiplist";
+import { RangeResolver } from "../resolver";
+
+describe("test skiplist", () => {
+  it("initializes a skiplist", () => {
+    const sl = new SkipList();
+    const head = sl.getSentinel();
+
+    expect(head.fieldName).toEqual("");
+    expect(head.fieldType).toEqual(0);
+    expect(head.mp).toEqual(null);
+  });
+
+  let mockRangeResolver: RangeResolver;
+  beforeEach(() => {
+    mockRangeResolver = async ([{ start, end }]) => {
+      return [
+        {
+          data: new ArrayBuffer(0),
+          totalLength: 0,
+        },
+      ];
+    };
+  });
+
+  it("inserts and queries", async () => {
+    const s = new SkipList();
+
+    const payload: { indexMeta: IndexMeta; metaPage: LinkedMetaPage }[] = [
+      {
+        indexMeta: {
+          fieldName: "a",
+          fieldType: FieldType.Null,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 0n),
+      },
+      {
+        indexMeta: {
+          fieldName: "a",
+          fieldType: FieldType.Boolean,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 1n),
+      },
+      {
+        indexMeta: {
+          fieldName: "ab",
+          fieldType: FieldType.String,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 2n),
+      },
+      {
+        indexMeta: {
+          fieldName: "b",
+          fieldType: FieldType.Float64,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 3n),
+      },
+
+      {
+        indexMeta: {
+          fieldName: "b",
+          fieldType: FieldType.Uint64,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 4n),
+      },
+
+      {
+        indexMeta: {
+          fieldName: "b",
+          fieldType: FieldType.Int64,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 5n),
+      },
+
+      {
+        indexMeta: {
+          fieldName: "x",
+          fieldType: FieldType.Float64,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 6n),
+      },
+
+      {
+        indexMeta: {
+          fieldName: "trip_distance",
+          fieldType: FieldType.Float64,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 7n),
+      },
+
+      {
+        indexMeta: {
+          fieldName: "wef",
+          fieldType: FieldType.Boolean,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 8n),
+      },
+      {
+        indexMeta: {
+          fieldName: "wef2",
+          fieldType: FieldType.Boolean,
+        },
+        metaPage: new LinkedMetaPage(mockRangeResolver, 9n),
+      },
+    ];
+
+    for (const { indexMeta, metaPage } of payload) {
+      await s.insert(indexMeta, metaPage);
+    }
+
+    for (const { indexMeta, metaPage } of payload) {
+      const mp = await s.search(indexMeta);
+      expect(mp).toEqual(metaPage);
+    }
+  });
+});


### PR DESCRIPTION
closes #138 

## Skiplist details
1. `coinFlip()` is a probabilistic balancing feature 
2. We treat the `IndexMeta` as the `SkipListNode's` composite key


- [x] wrote tests
- [x] counted searching time for demo. Variance where the quickest was 2 iterations and the average was ~16/2