### PR TITLE
feat: add useMultipart flag

### DIFF
--- a/examples/client/index.html
+++ b/examples/client/index.html
@@ -90,6 +90,7 @@
         Appendable.init(
           "green_tripdata_2023-01.jsonl",
           "green_tripdata_2023-01.index",
+          { useMultipartByteRanges: false },
         ).then(async (db) => {
           // populate fields
           db.fields().then((fields) => {

--- a/src/data-file.ts
+++ b/src/data-file.ts
@@ -1,14 +1,15 @@
+import { Config } from ".";
 import { requestRanges } from "./range-request";
-import { LengthIntegrityError, RangeResolver } from "./resolver";
+import { RangeResolver } from "./resolver";
 
 export class DataFile {
   private originalResolver?: RangeResolver;
 
   private constructor(private resolver: RangeResolver) {}
 
-  static forUrl(url: string) {
+  static forUrl(url: string, config: Config) {
     return DataFile.forResolver(
-      async (ranges) => await requestRanges(url, ranges),
+      async (ranges) => await requestRanges(url, ranges, config),
     );
   }
 

--- a/src/index-file/index-file.ts
+++ b/src/index-file/index-file.ts
@@ -13,11 +13,12 @@ import {
 } from "./meta";
 import { FieldType } from "../db/database";
 import { requestRanges } from "../range-request";
+import { Config } from "..";
 
 export class IndexFile {
-  static async forUrl<T = any>(url: string) {
+  static async forUrl<T = any>(url: string, config: Config) {
     return await IndexFile.forResolver<T>(
-      async (ranges) => await requestRanges(url, ranges),
+      async (ranges) => await requestRanges(url, ranges, config),
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,12 @@ export type Config = {
 export async function init(
   dataUrl: string | RangeResolver,
   indexUrl: string | RangeResolver,
-  config: Config,
+  config?: Config,
 ) {
+  if (!config) {
+    config = { useMultipartByteRanges: true };
+  }
+
   return Database.forDataFileAndIndexFile(
     typeof dataUrl === "string"
       ? DataFile.forUrl(dataUrl, config)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,21 @@ import { Database, FieldType, fieldTypeToString } from "./db/database";
 import { IndexFile } from "./index-file/index-file";
 import { RangeResolver } from "./resolver";
 
+export type Config = {
+  useMultipartByteRanges?: boolean;
+};
+
 export async function init(
   dataUrl: string | RangeResolver,
   indexUrl: string | RangeResolver,
+  config: Config,
 ) {
   return Database.forDataFileAndIndexFile(
     typeof dataUrl === "string"
-      ? DataFile.forUrl(dataUrl)
+      ? DataFile.forUrl(dataUrl, config)
       : DataFile.forResolver(dataUrl),
     typeof indexUrl === "string"
-      ? await IndexFile.forUrl(indexUrl)
+      ? await IndexFile.forUrl(indexUrl, config)
       : await IndexFile.forResolver(indexUrl),
   );
 }

--- a/src/range-request.ts
+++ b/src/range-request.ts
@@ -6,7 +6,6 @@ async function resolveIndividualPromises(
   url: string,
   ranges: { start: number; end: number; expectedLength?: number }[],
 ) {
-  console.log("resolving ranges individually");
   // fallback to resolving ranges individually
   const individualRangePromises = ranges.map(
     async ({ start, end, expectedLength }) => {
@@ -36,10 +35,7 @@ export async function requestRanges(
   config: Config,
 ): Promise<{ data: ArrayBuffer; totalLength: number }[]> {
   const { useMultipartByteRanges } = config;
-  if (
-    useMultipartByteRanges === false ||
-    useMultipartByteRanges === undefined
-  ) {
+  if (useMultipartByteRanges === false) {
     return await resolveIndividualPromises(url, ranges);
   }
 
@@ -57,7 +53,7 @@ export async function requestRanges(
   switch (response.status) {
     case 200:
       console.warn(
-        `useMultipartByteRanges has not been set to false. The server can not handle multipart byte ranges.`,
+        `useMultipartByteRanges is enabled but the server indicated did not respond with a subset of bytes. Set useMultipartByteRanges: false in your Appendable config object.`,
       );
       return await resolveIndividualPromises(url, ranges);
     case 206:


### PR DESCRIPTION
Closes #158 

In our `init()`, this PR introduces a `Config` which contains the following:

```ts
export type Config = {
     useMultipartByteRanges?: boolean
}
```

We drill this through and in `range-request.ts`, we add logic where if that flag is either undefined or false, we'll resolve each range individually, else we'll continue with multi-fetching. If we reach a `200` response when multi-fetching, we'll warn the user that this flag hasn't been set.

Tested via local