### PR TITLE
Set fixed width in `IndexMeta`

### DIFF
--- a/pkg/appendable/appendable.go
+++ b/pkg/appendable/appendable.go
@@ -127,12 +127,9 @@ type IndexMeta struct {
 	FieldWidth uint16
 }
 
-func (m *IndexMeta) MarshalBinary() ([]byte, error) {
-	buf := make([]byte, 2+2+len(m.FieldName)+2)
-	binary.LittleEndian.PutUint16(buf[0:], uint16(m.FieldType))
-
+func DetermineFieldWidth(t FieldType) uint16 {
 	var width uint16
-	switch m.FieldType {
+	switch t {
 	case FieldTypeFloat64, FieldTypeInt64:
 		width = 8
 	case FieldTypeBoolean:
@@ -143,7 +140,13 @@ func (m *IndexMeta) MarshalBinary() ([]byte, error) {
 		width = 0xFFFF
 	}
 
-	binary.LittleEndian.PutUint16(buf[2:], width)
+	return width
+}
+
+func (m *IndexMeta) MarshalBinary() ([]byte, error) {
+	buf := make([]byte, 2+2+len(m.FieldName)+2)
+	binary.LittleEndian.PutUint16(buf[0:], uint16(m.FieldType))
+	binary.LittleEndian.PutUint16(buf[2:], DetermineFieldWidth(m.FieldType))
 	binary.LittleEndian.PutUint16(buf[4:], uint16(len(m.FieldName)))
 	copy(buf[6:], m.FieldName)
 	return buf, nil

--- a/pkg/appendable/index_file.go
+++ b/pkg/appendable/index_file.go
@@ -185,10 +185,16 @@ func (i *IndexFile) FindOrCreateIndex(name string, fieldType FieldType) (*btree.
 	metadata := &IndexMeta{}
 	metadata.FieldName = name
 	metadata.FieldType = fieldType
+	fieldWidth := DetermineFieldWidth(fieldType)
+	metadata.FieldWidth = fieldWidth
+
 	buf, err := metadata.MarshalBinary()
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
 	}
+
+	next.FixedWidth = fieldWidth
+
 	return next, next.SetMetadata(buf)
 }
 

--- a/pkg/btree/bptree_test.go
+++ b/pkg/btree/bptree_test.go
@@ -26,6 +26,10 @@ func (m *testMetaPage) Root() (MemoryPointer, error) {
 	return m.root, nil
 }
 
+func (m *testMetaPage) GetWidth() uint16 {
+	return ^uint16(0)
+}
+
 func (m *testMetaPage) write() error {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, m.root.Offset)

--- a/pkg/btree/multi.go
+++ b/pkg/btree/multi.go
@@ -21,8 +21,9 @@ const N = 16
  * math.MaxUint64.
  */
 type LinkedMetaPage struct {
-	rws    ReadWriteSeekPager
-	offset uint64
+	rws        ReadWriteSeekPager
+	FixedWidth uint16
+	offset     uint64
 }
 
 func (m *LinkedMetaPage) Root() (MemoryPointer, error) {
@@ -38,6 +39,10 @@ func (m *LinkedMetaPage) SetRoot(mp MemoryPointer) error {
 		return err
 	}
 	return binary.Write(m.rws, binary.LittleEndian, mp)
+}
+
+func (m *LinkedMetaPage) GetWidth() uint16 {
+	return m.FixedWidth
 }
 
 // BPTree returns a B+ tree that uses this meta page as the root

--- a/pkg/btree/node.go
+++ b/pkg/btree/node.go
@@ -64,6 +64,7 @@ type BPTreeNode struct {
 	leafPointers     []MemoryPointer
 	internalPointers []uint64
 	Keys             []ReferencedValue
+	FixedWidth       uint16
 }
 
 func (n *BPTreeNode) Leaf() bool {
@@ -85,10 +86,8 @@ func (n *BPTreeNode) Size() int64 {
 	size := 4 // number of keys
 	for _, k := range n.Keys {
 		size += 12
-		if k.ElideValue {
-			size += 4
-		} else {
-			size += 4 + len(k.Value)
+		if n.FixedWidth != ^uint16(0) {
+			size += len(k.Value)
 		}
 	}
 	for range n.leafPointers {
@@ -117,12 +116,7 @@ func (n *BPTreeNode) MarshalBinary() ([]byte, error) {
 		binary.LittleEndian.PutUint64(buf[ct:ct+8], k.DataPointer.Offset)
 		binary.LittleEndian.PutUint32(buf[ct+8:ct+12], k.DataPointer.Length)
 		ct += 12
-		if k.ElideValue {
-			binary.LittleEndian.PutUint32(buf[ct:ct+4], ^uint32(0))
-			ct += 4
-		} else {
-			binary.LittleEndian.PutUint32(buf[ct:ct+4], uint32(len(k.Value)))
-			ct += 4
+		if n.FixedWidth != ^uint16(0) {
 			m := copy(buf[ct:ct+len(k.Value)], k.Value)
 			if m != len(k.Value) {
 				return nil, fmt.Errorf("failed to copy key: %w", io.ErrShortWrite)
@@ -174,16 +168,13 @@ func (n *BPTreeNode) UnmarshalBinary(buf []byte) error {
 		n.Keys[i].DataPointer.Length = binary.LittleEndian.Uint32(buf[m+8 : m+12])
 		m += 12
 
-		l := binary.LittleEndian.Uint32(buf[m : m+4])
-		m += 4
-		if l == ^uint32(0) {
+		if n.FixedWidth == ^uint16(0) {
 			// read the key out of the memory pointer stored at this position
-			n.Keys[i].ElideValue = true
 			dp := n.Keys[i].DataPointer
 			n.Keys[i].Value = n.DataParser.Parse(n.Data[dp.Offset : dp.Offset+uint64(dp.Length)]) // resolving the data-file
 		} else {
-			n.Keys[i].Value = buf[m : m+int(l)]
-			m += int(l)
+			n.Keys[i].Value = buf[m : m+int(n.FixedWidth)]
+			m += int(n.FixedWidth)
 		}
 	}
 	for i := range n.leafPointers {

--- a/pkg/mocks/main.go
+++ b/pkg/mocks/main.go
@@ -15,6 +15,10 @@ type testMetaPage struct {
 	root btree.MemoryPointer
 }
 
+func (m *testMetaPage) GetWidth() uint16 {
+	return ^uint16(0)
+}
+
 func (m *testMetaPage) SetRoot(mp btree.MemoryPointer) error {
 	m.root = mp
 	return m.write()

--- a/src/btree/bptree.ts
+++ b/src/btree/bptree.ts
@@ -19,6 +19,7 @@ export class BPTree {
   private readonly dataFileResolver: RangeResolver;
   private fileFormat: FileFormat;
   private pageFieldType: FieldType;
+  private pageFieldWidth: number;
 
   constructor(
     tree: RangeResolver,
@@ -26,12 +27,14 @@ export class BPTree {
     dataFileResolver: RangeResolver,
     fileFormat: FileFormat,
     pageFieldType: FieldType,
+    pageFieldWidth: number,
   ) {
     this.tree = tree;
     this.meta = meta;
     this.dataFileResolver = dataFileResolver;
     this.fileFormat = fileFormat;
     this.pageFieldType = pageFieldType;
+    this.pageFieldWidth = pageFieldWidth;
   }
 
   async root(): Promise<RootResponse> {
@@ -66,6 +69,7 @@ export class BPTree {
         this.dataFileResolver,
         this.fileFormat,
         this.pageFieldType,
+        this.pageFieldWidth,
       );
 
       if (!bytesRead) {

--- a/src/btree/multi.ts
+++ b/src/btree/multi.ts
@@ -4,6 +4,7 @@ import { MemoryPointer } from "./node";
 export const N = 16;
 export const PAGE_SIZE_BYTES = 4096;
 export const maxUint64 = 2n ** 64n - 1n;
+export const maxUint16 = 65535;
 
 export class LinkedMetaPage {
   private resolver: RangeResolver;

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -131,9 +131,8 @@ export class Database<T extends Schema> {
 
       const mps = await this.indexFile.seek(key as string, fieldType);
       const mp = mps[0];
-      const { fieldType: mpFieldType } = await readIndexMeta(
-        await mp.metadata(),
-      );
+      const { fieldType: mpFieldType, fieldWidth: mpFieldWidth } =
+        await readIndexMeta(await mp.metadata());
 
       let ord: "ASC" | "DESC" = "ASC";
       if (query.orderBy && query.orderBy[0]) {
@@ -146,6 +145,7 @@ export class Database<T extends Schema> {
         dfResolver,
         format,
         mpFieldType,
+        mpFieldWidth,
       );
 
       if (operation === ">") {

--- a/src/index-file/meta.ts
+++ b/src/index-file/meta.ts
@@ -36,6 +36,7 @@ export async function readFileMeta(buffer: ArrayBuffer): Promise<FileMeta> {
 
 export type IndexMeta = {
   fieldName: string;
+  fieldWidth: number;
   fieldType: number;
 };
 
@@ -45,23 +46,25 @@ export type IndexHeader = {
 };
 
 export async function readIndexMeta(buffer: ArrayBuffer): Promise<IndexMeta> {
-  if (buffer.byteLength < 4) {
+  if (buffer.byteLength < 6) {
     throw new Error(`invalid metadata size ${buffer.byteLength}`);
   }
 
   const dataView = new DataView(buffer);
   const fieldType = dataView.getUint16(0, true);
-  const nameLength = dataView.getUint16(2, true);
+  const fieldWidth = dataView.getUint16(2, true);
+  const nameLength = dataView.getUint16(4, true);
 
-  if (buffer.byteLength < 4 + nameLength) {
+  if (buffer.byteLength < 6 + nameLength) {
     throw new Error(`invalid metadata size ${buffer.byteLength}`);
   }
 
-  const fieldNameBuffer = buffer.slice(4, 4 + nameLength);
+  const fieldNameBuffer = buffer.slice(6, 6 + nameLength);
   const fieldName = new TextDecoder("utf-8").decode(fieldNameBuffer);
 
   return {
     fieldName,
+    fieldWidth,
     fieldType,
   };
 }

--- a/src/tests/bptree.test.ts
+++ b/src/tests/bptree.test.ts
@@ -1,4 +1,5 @@
 import { BPTree, MetaPage, ReferencedValue } from "../btree/bptree";
+import { maxUint16 } from "../btree/multi";
 import { MemoryPointer } from "../btree/node";
 import { FieldType } from "../db/database";
 import { FileFormat } from "../index-file/meta";
@@ -56,6 +57,7 @@ describe("test btree", () => {
       mockDataFileResolver,
       FileFormat.CSV,
       FieldType.Float64,
+      maxUint16,
     );
   });
 

--- a/src/tests/index-file.test.ts
+++ b/src/tests/index-file.test.ts
@@ -5,12 +5,10 @@ import { readBinaryFile } from "./test-util";
 
 describe("test index-file parsing", () => {
   let mockRangeResolver: RangeResolver;
-  let indexFileSize: number;
   let indexFile: Uint8Array;
 
   beforeAll(async () => {
     indexFile = await readBinaryFile("green_tripdata_2023-01.index");
-    indexFileSize = indexFile.byteLength;
   });
 
   beforeEach(() => {

--- a/src/tests/node.test.ts
+++ b/src/tests/node.test.ts
@@ -1,4 +1,5 @@
 import { ReferencedValue, binarySearchReferencedValues } from "../btree/bptree";
+import { maxUint16 } from "../btree/multi";
 import { BPTreeNode } from "../btree/node";
 import { FieldType } from "../db/database";
 import { FileFormat } from "../index-file/meta";
@@ -129,12 +130,13 @@ describe("node functionality", () => {
       ];
     };
 
-    const { node: leafNode, bytesRead } = await BPTreeNode.fromMemoryPointer(
+    const { node: leafNode } = await BPTreeNode.fromMemoryPointer(
       { offset: 0n, length: 1 },
       mockRangeResolver,
       mockDataResolver,
-      FileFormat.JSONL,
+      FileFormat.CSV,
       FieldType.String,
+      maxUint16,
     );
 
     expect(leafNode.internalPointers.length).toEqual(0);
@@ -193,6 +195,7 @@ describe("node functionality", () => {
       mockDataResolver,
       FileFormat.CSV,
       FieldType.String,
+      maxUint16,
     );
 
     expect(internalNode.internalPointers.length).toEqual(4);


### PR DESCRIPTION
Closes #152 

> [!NOTE]
> Still a draft PR. We'll need to update `node.go` and `bptree.go` to pass the `FixedWidth` information and remove the need of storing `l`


## What this PR contains

1. Allocates 2 bytes in the `IndexMeta` to specify the `FixedWidth` for that given multi page
2. Updated the `ts` reader so it reads the `FixedWidth` upon scanning the metadata, drills down to the `UnmarshalNode` logic, replacing the need to store the length (`l`) in disk

- [x] tested and works via demo