### PR TITLE
feat: reset metrics to demo

### DIFF
--- a/examples/client/index.html
+++ b/examples/client/index.html
@@ -131,6 +131,8 @@
 
           // then execute the query
           document.getElementById("execute").onclick = async () => {
+            numRequests = 0;
+            bytesReceived = 0;
             document.getElementById("results").innerHTML = "";
             document.getElementById("execute").disabled = true;
 


### PR DESCRIPTION
Just a note: the initial page load fetches ~40 requests, because a good portion of those are from retrieving the index headers.

We reset the counters when we click on the execute button, as `execute` requeries the db.

So we go from ~40 requests to 13 requests every time we click execute. Just a note, since people might be a bit confused by that.