### PR TITLE
ci: prettier

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -36,4 +36,4 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18"
-      - run: npx prettier --check . 2> $GITHUB_STEP_SUMMARY
+      - run: npx prettier --check "**/*.{js,jsx,ts,tsx,css,scss,md,json}"  2> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Prettier fails even though running `npx prettier --check "**/*.{js,jsx,ts,tsx,css,scss,md,json}"`Maybe the CI needs a tighter scope