### PR TITLE
Replace `%` for `&` + Benchmarks

### DIFF
--- a/pkg/pagefile/pagefile.go
+++ b/pkg/pagefile/pagefile.go
@@ -57,7 +57,7 @@ func NewPageFile(rws io.ReadWriteSeeker) (*PageFile, error) {
 			offset := int64(binary.LittleEndian.Uint64(buf[i*8 : (i+1)*8]))
 			if offset != 0 {
 				pf.freePageIndexes[pf.freePageHead] = offset
-				pf.freePageHead = (pf.freePageHead+1)&len(pf.freePageIndexes) - 1
+				pf.freePageHead = (pf.freePageHead + 1) & (len(pf.freePageIndexes) - 1)
 				pf.freePageCount++
 			} else {
 				break

--- a/pkg/pagefile/pagefile_test.go
+++ b/pkg/pagefile/pagefile_test.go
@@ -229,3 +229,53 @@ func TestPageFile(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkPageFile(b *testing.B) {
+
+	b.Run("Benchmark new page file", func(b *testing.B) {
+		buf := buftest.NewSeekableBuffer()
+
+		for i := 0; i < b.N; i++ {
+			_, _ = NewPageFile(buf)
+		}
+	})
+
+	b.Run("Benchmark writeFreePageIndices", func(b *testing.B) {
+		buf := buftest.NewSeekableBuffer()
+		pf, err := NewPageFile(buf)
+
+		if err != nil {
+			b.Fatalf("failed to create page file")
+		}
+
+		for i := 0; i < b.N; i++ {
+			_ = pf.writeFreePageIndices()
+		}
+	})
+
+	b.Run("Benchmark free page index", func(b *testing.B) {
+		buf := buftest.NewSeekableBuffer()
+		pf, err := NewPageFile(buf)
+
+		if err != nil {
+			b.Fatalf("failed to create page file")
+		}
+
+		for i := 0; i < b.N; i++ {
+			_, _ = pf.FreePageIndex()
+		}
+	})
+
+	b.Run("Benchmark new page", func(b *testing.B) {
+		buf := buftest.NewSeekableBuffer()
+		pf, err := NewPageFile(buf)
+
+		if err != nil {
+			b.Fatalf("failed to create page file")
+		}
+
+		for i := 0; i < b.N; i++ {
+			_, _ = pf.NewPage([]byte{0, 0, 0, 0, 0, 0, 0, 0})
+		}
+	})
+}


### PR DESCRIPTION
In `PageFile`, there are a lot of modulo computations. However, if the divisor is a base of 2, you can do the following:

`m % n === m & (n-1)`. [According to this blogpost](https://mziccard.me/2015/05/08/modulo-and-division-vs-bitwise-operations/), modulo takes multiple CPU cycles while bitwise only cycles once. 

Here are the benchmarks:

- modulo
```
goos: darwin
goarch: arm64
pkg: github.com/kevmo314/appendable/pkg/pagefile
BenchmarkPageFile
BenchmarkPageFile/Benchmark_new_page_file
BenchmarkPageFile/Benchmark_new_page_file-10         	 1546320	       774.8 ns/op
BenchmarkPageFile/Benchmark_writeFreePageIndices
BenchmarkPageFile/Benchmark_writeFreePageIndices-10  	 3029023	       396.1 ns/op
BenchmarkPageFile/Benchmark_free_page_index
BenchmarkPageFile/Benchmark_free_page_index-10       	586616586	         2.045 ns/op
BenchmarkPageFile/Benchmark_new_page
BenchmarkPageFile/Benchmark_new_page-10              	  495770	      2442 ns/op
```
<br>

- this is with bitwise

```
goos: darwin
goarch: arm64
pkg: github.com/kevmo314/appendable/pkg/pagefile
BenchmarkPageFile
BenchmarkPageFile/Benchmark_new_page_file
BenchmarkPageFile/Benchmark_new_page_file-10         	 1535476	       769.8 ns/op
BenchmarkPageFile/Benchmark_writeFreePageIndices
BenchmarkPageFile/Benchmark_writeFreePageIndices-10  	 2955009	       404.6 ns/op
BenchmarkPageFile/Benchmark_free_page_index
BenchmarkPageFile/Benchmark_free_page_index-10       	585331350	         2.050 ns/op
BenchmarkPageFile/Benchmark_new_page
BenchmarkPageFile/Benchmark_new_page-10              	  471688	      2182 ns/op
```