### PR TITLE
Defining trigrams

### DIFF
--- a/pkg/appendable/appendable.go
+++ b/pkg/appendable/appendable.go
@@ -53,11 +53,12 @@ const (
 	FieldTypeArray
 	FieldTypeBoolean
 	FieldTypeNull
+	FieldTypeTrigram
 )
 
 func (t FieldType) TypescriptType() string {
-	components := []string{}
-	if t&FieldTypeString != 0 {
+	var components []string
+	if t&FieldTypeString != 0 || t&FieldTypeTrigram != 0 {
 		components = append(components, "string")
 	}
 	if t&FieldTypeInt64 != 0 || t&FieldTypeFloat64 != 0 {

--- a/pkg/appendable/index_file.go
+++ b/pkg/appendable/index_file.go
@@ -2,11 +2,11 @@ package appendable
 
 import (
 	"fmt"
-	"github.com/kevmo314/appendable/pkg/metapage"
 	"io"
 	"time"
 
 	"github.com/kevmo314/appendable/pkg/btree"
+	"github.com/kevmo314/appendable/pkg/metapage"
 	"github.com/kevmo314/appendable/pkg/pagefile"
 )
 

--- a/pkg/btree/node.go
+++ b/pkg/btree/node.go
@@ -78,7 +78,6 @@ func SizeVariant(v uint64) int {
 }
 
 func (n *BPTreeNode) Size() int64 {
-
 	size := 4 // number of keys
 	for _, k := range n.Keys {
 		o := SizeVariant(uint64(k.DataPointer.Offset))

--- a/pkg/handlers/jsonl.go
+++ b/pkg/handlers/jsonl.go
@@ -147,6 +147,11 @@ func (j JSONLHandler) handleJSONLObject(f *appendable.IndexFile, r []byte, dec *
 
 			name := strings.Join(append(path, key), ".")
 
+			/*
+				if FieldTypeString == jsonTypeToFieldType(value) {
+					handle two pages at once here?
+				}
+			*/
 			page, err := f.FindOrCreateIndex(name, jsonTypeToFieldType(value))
 			if err != nil {
 				return fmt.Errorf("failed to find or create index: %w", err)
@@ -159,6 +164,7 @@ func (j JSONLHandler) handleJSONLObject(f *appendable.IndexFile, r []byte, dec *
 
 			switch value := value.(type) {
 			case string:
+				// string
 				valueBytes := []byte(value)
 
 				width := appendable.DetermineType(appendable.FieldTypeString)
@@ -169,6 +175,12 @@ func (j JSONLHandler) handleJSONLObject(f *appendable.IndexFile, r []byte, dec *
 				}, data); err != nil {
 					return fmt.Errorf("failed to insert into b+tree: %w", err)
 				}
+
+				// trigram work here
+				// for trigram in []byte(value) {
+				//		insert to bptree
+				// }
+
 			case json.Number, float64:
 				buf := make([]byte, 8)
 				switch value := value.(type) {


### PR DESCRIPTION
I'm wondering what the best design is to inject trigrams in the existing indexing service.

The initial thought was to extend the `FieldType` to include a `FieldTypeTrigram`, which would mean upon handling the json object, if it's a string, do double work. 