### PR TITLE
feat: pass width upon index creation

### DIFF
--- a/pkg/appendable/appendable.go
+++ b/pkg/appendable/appendable.go
@@ -81,6 +81,11 @@ func (t FieldType) TypescriptType() string {
 	return strings.Join(components, " | ")
 }
 
+type Metadata interface {
+	FileMeta
+	IndexMeta
+}
+
 type FileMeta struct {
 	Version
 	Format

--- a/pkg/appendable/appendable.go
+++ b/pkg/appendable/appendable.go
@@ -81,11 +81,6 @@ func (t FieldType) TypescriptType() string {
 	return strings.Join(components, " | ")
 }
 
-type Metadata interface {
-	FileMeta
-	IndexMeta
-}
-
 type FileMeta struct {
 	Version
 	Format

--- a/pkg/appendable/index_file.go
+++ b/pkg/appendable/index_file.go
@@ -154,38 +154,38 @@ func (i *IndexFile) IndexFieldNames() ([]string, error) {
 	return fieldNames, nil
 }
 
-func (i *IndexFile) FindOrCreateIndex(name string, fieldType FieldType) (*metapage.LinkedMetaSlot, uint16, error) {
+func (i *IndexFile) FindOrCreateIndex(name string, fieldType FieldType) (*metapage.LinkedMetaSlot, *IndexMeta, error) {
 	mp := i.tree
 	for {
 		// this is done in an odd order to avoid needing to keep track of the previous page
 		next, err := mp.Next()
 		if err != nil {
-			return nil, ^uint16(0), fmt.Errorf("failed to get next meta page: %w", err)
+			return nil, nil, fmt.Errorf("failed to get next meta page: %w", err)
 		}
 		exists, err := next.Exists()
 		if err != nil {
-			return nil, ^uint16(0), fmt.Errorf("failed to check if meta page exists: %w", err)
+			return nil, nil, fmt.Errorf("failed to check if meta page exists: %w", err)
 		}
 		if !exists {
 			break
 		}
 		buf, err := next.Metadata()
 		if err != nil {
-			return nil, ^uint16(0), fmt.Errorf("failed to read metadata: %w", err)
+			return nil, nil, fmt.Errorf("failed to read metadata: %w", err)
 		}
 		metadata := &IndexMeta{}
 		if err := metadata.UnmarshalBinary(buf); err != nil {
-			return nil, ^uint16(0), fmt.Errorf("failed to unmarshal metadata: %w", err)
+			return nil, nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
 		}
 		if metadata.FieldName == name && metadata.FieldType == fieldType {
-			return next, metadata.Width, nil
+			return next, metadata, nil
 		}
 		mp = next
 	}
 	// we haven't found the index, so we need to create it
 	next, err := mp.AddNext()
 	if err != nil {
-		return nil, ^uint16(0), fmt.Errorf("failed to add next meta page: %w", err)
+		return nil, nil, fmt.Errorf("failed to add next meta page: %w", err)
 	}
 	metadata := &IndexMeta{}
 	metadata.FieldName = name
@@ -193,9 +193,9 @@ func (i *IndexFile) FindOrCreateIndex(name string, fieldType FieldType) (*metapa
 	metadata.Width = DetermineType(fieldType)
 	buf, err := metadata.MarshalBinary()
 	if err != nil {
-		return nil, ^uint16(0), fmt.Errorf("failed to marshal metadata: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal metadata: %w", err)
 	}
-	return next, metadata.Width, next.SetMetadata(buf)
+	return next, metadata, next.SetMetadata(buf)
 }
 
 func (i *IndexFile) UpdateOffsets() error {

--- a/pkg/handlers/csv.go
+++ b/pkg/handlers/csv.go
@@ -173,7 +173,7 @@ func (c CSVHandler) handleCSVLine(f *appendable.IndexFile, df []byte, dec *csv.R
 		fieldLength := uint32(len(fieldValue))
 
 		_, fieldType := InferCSVField(fieldValue)
-		page, err := f.FindOrCreateIndex(name, fieldType)
+		page, _, err := f.FindOrCreateIndex(name, fieldType)
 
 		if err != nil {
 			return fmt.Errorf("failed to find or create index: %w", err)

--- a/pkg/handlers/jsonl.go
+++ b/pkg/handlers/jsonl.go
@@ -147,7 +147,9 @@ func (j JSONLHandler) handleJSONLObject(f *appendable.IndexFile, r []byte, dec *
 
 			name := strings.Join(append(path, key), ".")
 
-			page, width, err := f.FindOrCreateIndex(name, jsonTypeToFieldType(value))
+			page, meta, err := f.FindOrCreateIndex(name, jsonTypeToFieldType(value))
+			width := meta.Width
+
 			if err != nil {
 				return fmt.Errorf("failed to find or create index: %w", err)
 			}


### PR DESCRIPTION
We were doing double work where in `handleJsonlObject`, we'd recompute the width value upon json token. Instead, we read the width directly from the metaslot