### PR TITLE
feat: handle no results yielded

### DIFF
--- a/src/btree/traversal.ts
+++ b/src/btree/traversal.ts
@@ -29,11 +29,7 @@ export class TraversalIterator {
     const offset = rootResponse.pointer;
     this.records = await this.tree.traverse(this.key, root, offset);
 
-    if (this.records[0].index === this.records[0].node.leafPointers.length) {
-      return false;
-    }
-
-    return true;
+    return this.records[0].index !== this.records[0].node.numPointers();
   }
 
   getKey(): ReferencedValue {

--- a/src/btree/traversal.ts
+++ b/src/btree/traversal.ts
@@ -28,7 +28,8 @@ export class TraversalIterator {
     const root = rootResponse.rootNode;
     const offset = rootResponse.pointer;
     this.records = await this.tree.traverse(this.key, root, offset);
-    return true;
+
+    return this.records[0].index !== this.records[0].node.numPointers();
   }
 
   getKey(): ReferencedValue {

--- a/src/btree/traversal.ts
+++ b/src/btree/traversal.ts
@@ -29,7 +29,11 @@ export class TraversalIterator {
     const offset = rootResponse.pointer;
     this.records = await this.tree.traverse(this.key, root, offset);
 
-    return this.records[0].index !== this.records[0].node.numPointers();
+    if (this.records[0].index === this.records[0].node.leafPointers.length) {
+      return false;
+    }
+
+    return true;
   }
 
   getKey(): ReferencedValue {


### PR DESCRIPTION
The `TraversalRecord`'s first element returns a leaf node. When there are no fitting records, we return an index, `i`, right outside the bounds of `leafPointers`. That is from `0..len(leafPointers)-1`, index is usually `len(leafPointers)`. 

This PR adds one extra catch statement within the `init()` that checks this assertion. If true, we return false.