### PR TITLE
feat: specify trigram

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,9 +13,21 @@ import (
 	"github.com/kevmo314/appendable/pkg/mmap"
 )
 
+type StringSlice []string
+
+func (s *StringSlice) String() string {
+	return fmt.Sprintf("%v", *s)
+}
+
+func (s *StringSlice) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
 func main() {
 	var debugFlag, jsonlFlag, csvFlag, showTimings bool
 	var indexFilename, pprofFilename, benchmarkFilename string
+	var searchHeaders StringSlice
 
 	flag.BoolVar(&debugFlag, "debug", false, "Use logger that prints at the debug-level")
 	flag.BoolVar(&jsonlFlag, "jsonl", false, "Use JSONL handler")
@@ -24,8 +36,10 @@ func main() {
 	flag.StringVar(&indexFilename, "i", "", "Specify the existing index of the file to be opened, writing to stdout")
 	flag.StringVar(&pprofFilename, "pprof", "", "Specify the file to write the pprof data to")
 	flag.StringVar(&benchmarkFilename, "b", "", "Specify the file to write the benchmark data to")
+	flag.Var(&searchHeaders, "s", "Specify the headers you want to search")
 
 	flag.Parse()
+
 	logLevel := &slog.LevelVar{}
 
 	if debugFlag {
@@ -92,7 +106,7 @@ func main() {
 	defer mmpif.Close()
 
 	// Open the index file
-	i, err := appendable.NewIndexFile(mmpif, dataHandler)
+	i, err := appendable.NewIndexFile(mmpif, dataHandler, searchHeaders)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/appendable/index_file_test.go
+++ b/pkg/appendable/index_file_test.go
@@ -24,12 +24,18 @@ func TestIndexFile(t *testing.T) {
 	t.Run("validate metadata throws error if format doesn't match on second read", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
 
-		if _, err := NewIndexFile(f, &FormatHandler{ReturnsFormat: Format(1)}); err != nil {
+		var em []string
+
+		if _, err := NewIndexFile(
+			f,
+			&FormatHandler{ReturnsFormat: Format(1)},
+			em,
+		); err != nil {
 			t.Fatal(err)
 		}
 
 		// try creating a new index file with a different format
-		if _, err := NewIndexFile(f, &FormatHandler{ReturnsFormat: Format(2)}); err == nil {
+		if _, err := NewIndexFile(f, &FormatHandler{ReturnsFormat: Format(2)}, em); err == nil {
 			t.Fatal("expected error")
 		}
 	})

--- a/pkg/btree/bptree.go
+++ b/pkg/btree/bptree.go
@@ -224,7 +224,6 @@ func (t *BPTree) traverse(key ReferencedValue, node *BPTreeNode, ptr pointer.Mem
 	// binary search node.Keys to find the first key greater than key
 	index, found := slices.BinarySearchFunc(node.Keys, key, CompareReferencedValues)
 
-	fmt.Printf("index: %v", index)
 	if node.Leaf() {
 		return []TraversalRecord{{node: node, index: index, ptr: ptr}}, nil
 	}

--- a/pkg/handlers/csv_test.go
+++ b/pkg/handlers/csv_test.go
@@ -31,7 +31,9 @@ func TestCSV(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
 		g := []byte("test\ntest1\n")
 
-		i, err := appendable.NewIndexFile(f, CSVHandler{})
+		var em []string
+
+		i, err := appendable.NewIndexFile(f, CSVHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -74,7 +76,9 @@ func TestCSV(t *testing.T) {
 
 		f := buftest.NewSeekableBuffer()
 
-		i, err := appendable.NewIndexFile(f, CSVHandler{})
+		var em []string
+
+		i, err := appendable.NewIndexFile(f, CSVHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -141,7 +145,8 @@ func TestCSV(t *testing.T) {
 
 		f := buftest.NewSeekableBuffer()
 
-		i, err := appendable.NewIndexFile(f, CSVHandler{})
+		var em []string
+		i, err := appendable.NewIndexFile(f, CSVHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -230,7 +235,9 @@ func TestCSV(t *testing.T) {
 
 		f := buftest.NewSeekableBuffer()
 
-		i, err := appendable.NewIndexFile(f, CSVHandler{})
+		var em []string
+
+		i, err := appendable.NewIndexFile(f, CSVHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -273,7 +280,8 @@ func TestCSV(t *testing.T) {
 
 	t.Run("correctly iterates through btree", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
-		i, err := appendable.NewIndexFile(f, CSVHandler{})
+		var em []string
+		i, err := appendable.NewIndexFile(f, CSVHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/handlers/jsonl.go
+++ b/pkg/handlers/jsonl.go
@@ -82,7 +82,7 @@ func jsonTypeToFieldType(t json.Token) []appendable.FieldType {
 	case json.Number, float64:
 		return []appendable.FieldType{appendable.FieldTypeFloat64}
 	case string:
-		return []appendable.FieldType{appendable.FieldTypeString, appendable.FieldTypeTrigram}
+		return []appendable.FieldType{appendable.FieldTypeString}
 	case bool:
 		return []appendable.FieldType{appendable.FieldTypeBoolean}
 	case nil:
@@ -148,7 +148,12 @@ func (j JSONLHandler) handleJSONLObject(f *appendable.IndexFile, r []byte, dec *
 
 			name := strings.Join(append(path, key), ".")
 
-			for _, ft := range jsonTypeToFieldType(value) {
+			fts := jsonTypeToFieldType(value)
+			if f.IsSearch(name) {
+				fts = append(fts, appendable.FieldTypeTrigram)
+			}
+
+			for _, ft := range fts {
 				page, meta, err := f.FindOrCreateIndex(name, ft)
 				if err != nil {
 					return fmt.Errorf("failed to find or create index: %w", err)

--- a/pkg/handlers/jsonl_test.go
+++ b/pkg/handlers/jsonl_test.go
@@ -19,7 +19,9 @@ func TestJSONL(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
 		g := []byte("{\"test\":\"test1\"}\n")
 
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		em := []string{"test"}
+
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -60,8 +62,8 @@ func TestJSONL(t *testing.T) {
 
 	t.Run("correctly sets field offset", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
-
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		em := []string{"test"}
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -125,8 +127,9 @@ func TestJSONL(t *testing.T) {
 
 	t.Run("new index", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
+		em := []string{"test", "test2"}
 
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -228,8 +231,8 @@ func TestJSONL(t *testing.T) {
 
 	t.Run("existing index but different type", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
-
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		var em []string
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -254,8 +257,8 @@ func TestJSONL(t *testing.T) {
 		}
 
 		// check that the index file now has the additional index
-		if len(collected) != 3 {
-			t.Errorf("got len(i.Indexes) = %d, want 1", len(collected))
+		if len(collected) != 2 {
+			t.Errorf("got len(i.Indexes) = %d, want 2", len(collected))
 		}
 
 		var vanillaIndexes []*metapage.LinkedMetaSlot
@@ -332,8 +335,8 @@ func TestJSONL(t *testing.T) {
 
 	t.Run("creates nested indices", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
-
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		var em []string
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -353,7 +356,7 @@ func TestJSONL(t *testing.T) {
 		}
 
 		// check that the index file now has the additional data ranges but same number of indices
-		if len(collected) != 6 {
+		if len(collected) != 4 {
 			t.Errorf("got len(i.Indexes) = %d, want 4", len(collected))
 		}
 
@@ -430,7 +433,8 @@ func TestJSONL(t *testing.T) {
 	t.Run("creates second indices with same parent", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
 
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		var em []string
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -450,7 +454,7 @@ func TestJSONL(t *testing.T) {
 		}
 
 		// check that the index file now has the additional data ranges but same number of indices
-		if len(collected) != 6 {
+		if len(collected) != 4 {
 			t.Errorf("got len(i.Indexes) = %d, want 4", len(collected))
 		}
 
@@ -526,8 +530,8 @@ func TestJSONL(t *testing.T) {
 
 	t.Run("creates index for arrays", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
-
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		em := []string{"test"}
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -598,7 +602,8 @@ func TestJSONL(t *testing.T) {
 	t.Run("existing index but nullable type", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
 
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		var em []string
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -623,8 +628,8 @@ func TestJSONL(t *testing.T) {
 		}
 
 		// check that the index file now has the additional index
-		if len(collected) != 3 {
-			t.Errorf("got len(i.Indexes) = %d, want 1", len(collected))
+		if len(collected) != 2 {
+			t.Errorf("got len(i.Indexes) = %d, want 2", len(collected))
 		}
 
 		var vanillaIndexes []*metapage.LinkedMetaSlot
@@ -706,8 +711,8 @@ func TestJSONL(t *testing.T) {
 		r2 := []byte("{\"nullheader\":null}\n{\"nullheader\":null}\n")
 
 		f := buftest.NewSeekableBuffer()
-
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		var em []string
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -751,7 +756,8 @@ func TestJSONL(t *testing.T) {
 	t.Run("correctly iterates through btree", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
 
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		var em []string
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -798,8 +804,8 @@ func TestJSONL(t *testing.T) {
 
 	t.Run("able to insert trigrams and find trigrams", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
-
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		em := []string{"test"}
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -866,8 +872,8 @@ func TestJSONL(t *testing.T) {
 
 	t.Run("iteratively search", func(t *testing.T) {
 		f := buftest.NewSeekableBuffer()
-
-		i, err := appendable.NewIndexFile(f, JSONLHandler{})
+		em := []string{"test"}
+		i, err := appendable.NewIndexFile(f, JSONLHandler{}, em)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Closes #203 

This PR extends the CLI to specify a list of headers you wish to index.

Sample:
```sh
go run cmd/main.go -t -i  randdata.index -s wef -s yearn -jsonl randdata.jsonl  
```

We collect all strings with the `-s` tag to denote as "searchable". We drill this through, and before creating the pages and inserting the bptree, we check if a given `name` is searchable.

