### PR TITLE
feat: reproduce failing test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ examples/client/appendable.min.js.map
 # But include these files in src/tests/mock_binaries
 !src/tests/mock_binaries/*.jsonl
 !src/tests/mock_binaries/*.cs
+!src/tests/mock_binaries/*.index

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -124,6 +124,14 @@ func main() {
 		panic(err)
 	}
 
+	fh, err := i.IndexFieldNames()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%v\n", fh)
+
 	if showTimings {
 		readDuration := time.Since(readStart)
 		logger.Info("Opening + synchronizing index file took", slog.Duration("duration", readDuration))

--- a/src/tests/multi.test.ts
+++ b/src/tests/multi.test.ts
@@ -26,3 +26,27 @@ describe("test metadata", () => {
     expect("hello").toEqual(arrayBufferToString(metadata));
   });
 });
+
+describe("paloalto metadata", () => {
+  let mockMetadata: Uint8Array;
+
+  beforeAll(async () => {
+    mockMetadata = await readBinaryFile("palo-alto.index");
+  });
+
+  it("reads paloalto metadata", async () => {
+    const mockRangeResolver: RangeResolver = async ([{ start, end }]) => {
+      return [
+        {
+          data: mockMetadata.buffer.slice(start, end),
+          totalLength: end - start + 1,
+        },
+      ];
+    };
+
+    const tree = ReadMultiBPTree(mockRangeResolver, 0);
+    const ms = await tree.splitPage();
+
+    expect(ms.length).toBeGreaterThan(1); // expected to have the fol
+  });
+});


### PR DESCRIPTION
The test case in `multi.test.ts` is currently failing upon feeding in the `palo-alto.index` file.