### PR TITLE
feat: rename `NextSlot`

### DIFF
--- a/pkg/metapage/multi.go
+++ b/pkg/metapage/multi.go
@@ -86,7 +86,7 @@ func (m *MultiPager) Next(offset uint64) (*LinkedMetaSlot, error) {
 	return &LinkedMetaSlot{offset: next.Offset, pager: m}, nil
 }
 
-func (m *MultiPager) NextSlot(buf []byte) (int64, error) {
+func (m *MultiPager) GetNextSlot(buf []byte) (int64, error) {
 	if buf != nil && len(buf) > m.rws.SlotSize() {
 		return 0, errors.New("buffer is too large")
 	}
@@ -128,7 +128,7 @@ func (m *MultiPager) AddNext(offset uint64) (*LinkedMetaSlot, error) {
 		return nil, errors.New("next pointer already exists")
 	}
 
-	nextOffset, err := m.NextSlot(nil)
+	nextOffset, err := m.GetNextSlot(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/metapage/multi_test.go
+++ b/pkg/metapage/multi_test.go
@@ -39,7 +39,7 @@ func TestMetaPager(t *testing.T) {
 		s := make([]int64, nm)
 
 		for i := 0; i < nm; i++ {
-			offset, err := m.NextSlot(nil)
+			offset, err := m.GetNextSlot(nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -62,7 +62,7 @@ func TestMetaPager(t *testing.T) {
 		m := New(pf)
 
 		n := 26
-		offset, err := m.NextSlot(nil)
+		offset, err := m.GetNextSlot(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -74,7 +74,7 @@ func TestMetaPager(t *testing.T) {
 		var lastOffset int64 = -1
 
 		for i := 0; i < n; i++ {
-			offset, err = m.NextSlot(nil)
+			offset, err = m.GetNextSlot(nil)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Similar methods like Next involve interacting with the buffer to read/write. Renamed this to be a getter fn