### PR TITLE
New slotting logic

### DIFF
--- a/pkg/metapage/multi.go
+++ b/pkg/metapage/multi.go
@@ -51,7 +51,7 @@ func (m *MultiPager) Metadata(offset uint64) ([]byte, error) {
 	if _, err := m.rws.Seek(int64(offset)+24, io.SeekStart); err != nil {
 		return nil, err
 	}
-	buf := make([]byte, m.rws.SlotSize()-24)
+	buf := make([]byte, m.rws.PageSize()-24)
 	if _, err := m.rws.Read(buf); err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (m *MultiPager) Metadata(offset uint64) ([]byte, error) {
 }
 
 func (m *MultiPager) SetMetadata(offset uint64, data []byte) error {
-	if len(data) > m.rws.SlotSize()-24 {
+	if len(data) > m.rws.PageSize()-24 {
 		return errors.New("metadata too large")
 	}
 	if _, err := m.rws.Seek(int64(offset)+24, io.SeekStart); err != nil {

--- a/pkg/metapage/multi.go
+++ b/pkg/metapage/multi.go
@@ -146,7 +146,7 @@ func (m *MultiPager) AddNext(offset uint64) (*LinkedMetaSlot, error) {
 	return next, nil
 }
 
-func (m *MultiPager) Exists(offset uint64) (bool, error) {
+func (m *MultiPager) spaceExists(offset uint64, size int) (bool, error) {
 	if offset == ^uint64(0) {
 		return false, nil
 	}
@@ -154,7 +154,7 @@ func (m *MultiPager) Exists(offset uint64) (bool, error) {
 	if _, err := m.rws.Seek(int64(offset), io.SeekStart); err != nil {
 		return false, err
 	}
-	if _, err := m.rws.Read(make([]byte, m.rws.PageSize())); err != nil {
+	if _, err := m.rws.Read(make([]byte, size)); err != nil {
 		if err == io.EOF {
 			return false, nil
 		}
@@ -163,9 +163,17 @@ func (m *MultiPager) Exists(offset uint64) (bool, error) {
 	return true, nil
 }
 
-func (m *MultiPager) Reset(offset uint64) error {
-	// write a full page of zeros
-	emptyPage := make([]byte, m.rws.PageSize())
+func (m *MultiPager) SlotExists(offset uint64) (bool, error) {
+	return m.spaceExists(offset, m.rws.SlotSize())
+}
+
+func (m *MultiPager) PageExists(offset uint64) (bool, error) {
+	return m.spaceExists(offset, m.rws.PageSize())
+}
+
+func (m *MultiPager) spaceReset(offset uint64, size int) error {
+	// write a full slot of zeros
+	emptyPage := make([]byte, size)
 	binary.LittleEndian.PutUint64(emptyPage[12:20], ^uint64(0))
 	if _, err := m.rws.Seek(int64(offset), io.SeekStart); err != nil {
 		return err
@@ -174,4 +182,12 @@ func (m *MultiPager) Reset(offset uint64) error {
 		return err
 	}
 	return nil
+}
+
+func (m *MultiPager) PageReset(offset uint64) error {
+	return m.spaceReset(offset, m.rws.PageSize())
+}
+
+func (m *MultiPager) SlotReset(offset uint64) error {
+	return m.spaceReset(offset, m.rws.SlotSize())
 }

--- a/pkg/metapage/multi.go
+++ b/pkg/metapage/multi.go
@@ -51,7 +51,7 @@ func (m *MultiPager) Metadata(offset uint64) ([]byte, error) {
 	if _, err := m.rws.Seek(int64(offset)+24, io.SeekStart); err != nil {
 		return nil, err
 	}
-	buf := make([]byte, m.rws.PageSize()-24)
+	buf := make([]byte, m.rws.SlotSize()-24)
 	if _, err := m.rws.Read(buf); err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (m *MultiPager) Metadata(offset uint64) ([]byte, error) {
 }
 
 func (m *MultiPager) SetMetadata(offset uint64, data []byte) error {
-	if len(data) > m.rws.PageSize()-24 {
+	if len(data) > m.rws.SlotSize()-24 {
 		return errors.New("metadata too large")
 	}
 	if _, err := m.rws.Seek(int64(offset)+24, io.SeekStart); err != nil {

--- a/pkg/metapage/multi_test.go
+++ b/pkg/metapage/multi_test.go
@@ -39,70 +39,12 @@ func TestMetaPager(t *testing.T) {
 		s := make([]int64, nm)
 
 		for i := 0; i < nm; i++ {
-			offset, err := m.GetNextSlot(nil)
+			offset, err := m.GetNextSlot()
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			s[i] = offset
-			if offset/int64(m.rws.PageSize()) != 0 {
-				t.Fatalf("expected all meta pages to be in page 0, got page: %v", offset/int64(m.rws.PageSize()))
-			}
-
-		}
-	})
-
-	t.Run("reuse freed meta page", func(t *testing.T) {
-		buf := buftest.NewSeekableBuffer()
-		pf, err := pagefile.NewPageFile(buf)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		m := New(pf)
-
-		n := 26
-		offset, err := m.GetNextSlot(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if offset != 0 {
-			t.Fatalf("expected offset: 0, got: %v", offset)
-		}
-
-		var lastOffset int64 = -1
-
-		for i := 0; i < n; i++ {
-			offset, err = m.GetNextSlot(nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if i == 0 {
-				lastOffset = offset
-			} else {
-				expectedOffset := lastOffset + int64(m.rws.SlotSize())
-
-				if offset != expectedOffset {
-					t.Fatalf("expected recycled offset: %v, got %v at step %v", expectedOffset, offset, i)
-				}
-				lastOffset = offset
-			}
-
-			if i < 15 {
-				if pf.PageCount() != 1 {
-					t.Fatalf("expected page count to be 1, got: %v at %v", pf.PageCount(), i)
-				}
-			} else {
-				if pf.PageCount() != 2 {
-					t.Fatalf("expected page count to be 1, got: %v at %v", pf.PageCount(), i)
-				}
-			}
-
-		}
-		if pf.PageCount() != 2 {
-			t.Fatalf("expected page count to be 2, got: %v", pf.PageCount())
 		}
 	})
 }

--- a/pkg/metapage/slot.go
+++ b/pkg/metapage/slot.go
@@ -128,5 +128,6 @@ func NewMultiBPTree(t pagefile.ReadWriteSeekPager, ms *MultiPager, page int) (*L
 	if err != nil {
 		return nil, err
 	}
+	ms.freeSlotIndexes[0][0] = true
 	return &LinkedMetaSlot{pager: ms, offset: uint64(offset)}, nil
 }

--- a/pkg/metapage/slot.go
+++ b/pkg/metapage/slot.go
@@ -80,11 +80,11 @@ func (m *LinkedMetaSlot) MemoryPointer() pointer.MemoryPointer {
 }
 
 func (m *LinkedMetaSlot) Exists() (bool, error) {
-	return m.pager.Exists(m.offset)
+	return m.pager.SlotExists(m.offset)
 }
 
 func (m *LinkedMetaSlot) Reset() error {
-	return m.pager.Reset(m.offset)
+	return m.pager.SlotReset(m.offset)
 }
 
 // Collect returns a slice of all linked meta pages from this page to the end.

--- a/pkg/metapage/slot_test.go
+++ b/pkg/metapage/slot_test.go
@@ -218,29 +218,73 @@ func TestMultiBPTree(t *testing.T) {
 		}
 
 		// Create a linked list of LinkedMetaSlots
-		page1, err := tree.AddNext()
+		slot1, err := tree.AddNext()
 		if err != nil {
 			t.Fatal(err)
 		}
-		page2, err := page1.AddNext()
+		slot2, err := slot1.AddNext()
 		if err != nil {
 			t.Fatal(err)
 		}
-		page3, err := page2.AddNext()
+		slot3, err := slot2.AddNext()
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Collect the pages
-		collectedPages, err := page1.Collect()
+		collectedSlots, err := slot1.Collect()
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Verify the collected pages
-		expectedPages := []*LinkedMetaSlot{page1, page2, page3}
-		if !reflect.DeepEqual(collectedPages, expectedPages) {
-			t.Fatalf("got %v, want %v", collectedPages, expectedPages)
+		expectedSlots := []*LinkedMetaSlot{slot1, slot2, slot3}
+		if !reflect.DeepEqual(collectedSlots, expectedSlots) {
+			t.Fatalf("got %v, want %v", collectedSlots, expectedSlots)
+		}
+	})
+
+	t.Run("collect N slots for m pages", func(t *testing.T) {
+		b := buftest.NewSeekableBuffer()
+		p, err := pagefile.NewPageFile(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ms := New(p)
+		tree, err := NewMultiBPTree(p, ms, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := tree.Reset(); err != nil {
+			t.Fatal(err)
+		}
+
+		N := 30
+
+		// Create a linked list of LinkedMetaSlots
+		currSlot, err := tree.AddNext()
+		slot1 := currSlot
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 1; i < N; i++ {
+			newSlot, err := currSlot.AddNext()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			currSlot = newSlot
+		}
+
+		// Collect the pages
+		collectedPages, err := slot1.Collect()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(collectedPages) != N {
+			t.Fatalf("expected collected pages to be %v, got %v", N, len(collectedPages))
 		}
 	})
 

--- a/pkg/metapage/slot_test.go
+++ b/pkg/metapage/slot_test.go
@@ -331,36 +331,4 @@ func TestMultiBPTree(t *testing.T) {
 			t.Fatalf("got %v, want nil", collectedPages)
 		}
 	})
-
-	/*
-		t.Run("packs slot into one page", func(t *testing.T) {
-			b := buftest.NewSeekableBuffer()
-			p, err := pagefile.NewPageFile(b)
-			if err != nil {
-				t.Fatal(err)
-			}
-			ms := New(p)
-			currPage, err := NewMultiBPTree(p, ms, 0)
-			if err := currPage.Reset(); err != nil {
-				t.Fatal(err)
-			}
-
-			n := 26
-			for i := 0; i < n; i++ {
-				nextPage, err := currPage.AddNext()
-				if err != nil {
-					t.Fatalf("%v at %v", err, i)
-				}
-
-				if (i/16 + 1) != int(p.PageCount()) {
-					t.Fatalf("expected %v, got %v", i/16+1, p.PageCount())
-				}
-				currPage = nextPage
-			}
-
-			if len(ms.freeSlotIndexes) != 2 {
-				t.Fatalf("expected slot indexes to be 2, got %v", len(ms.freeSlotIndexes))
-			}
-		})
-	*/
 }

--- a/pkg/pagefile/pagefile.go
+++ b/pkg/pagefile/pagefile.go
@@ -17,6 +17,8 @@ type ReadWriteSeekPager interface {
 
 	PageSize() int
 	SlotSize() int
+
+	PageCount() int64
 }
 
 type PageFile struct {


### PR DESCRIPTION
`GetNextSlot()` doesn't take a `[]byte` since that wasn't used anywhere.

In addition, we use a `[][]bool` to keep track of the number of slots. Upon initializing the tree slot, we should fill the first element as true. In addition, the page index computation was off by 1.