### PR TITLE
coverage: slots

### DIFF
--- a/pkg/metapage/multi_test.go
+++ b/pkg/metapage/multi_test.go
@@ -47,4 +47,165 @@ func TestMetaPager(t *testing.T) {
 			s[i] = offset
 		}
 	})
+
+	t.Run("sets the first slot to filled", func(t *testing.T) {
+		buf := buftest.NewSeekableBuffer()
+		pf, err := pagefile.NewPageFile(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		m := New(pf)
+
+		tree, err := NewMultiBPTree(pf, m, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(m.freeSlotIndexes) != 1 {
+			t.Fatalf("expect length of free slot indexes to be 1, got %v", len(m.freeSlotIndexes))
+		}
+
+		if !m.freeSlotIndexes[0][0] {
+			t.Fatal("expected 0, 0 to be filled as true")
+		}
+
+		if tree.offset != 4096 {
+			t.Fatal("expected tree offset to be 4096")
+		}
+	})
+
+	t.Run("fills up one page", func(t *testing.T) {
+		buf := buftest.NewSeekableBuffer()
+		pf, err := pagefile.NewPageFile(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		m := New(pf)
+
+		tree, err := NewMultiBPTree(pf, m, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := tree.Reset(); err != nil {
+			t.Fatal(err)
+		}
+
+		prevSlot := tree
+		for i := 1; i < 16; i++ { // we start from 1 because tree was technically 0th
+			newSlot, err := prevSlot.AddNext()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			prevSlot = newSlot
+
+			if m.rws.PageCount() != 1 {
+				t.Fatal("expect only one page to occur")
+			}
+		}
+		if m.rws.PageCount() != 1 {
+			t.Fatal("expect only one page to occur")
+		}
+
+		if len(m.freeSlotIndexes) != 1 {
+			t.Fatalf("expected free slot indexes to be of length 1, got %v", len(m.freeSlotIndexes))
+		}
+
+		slots, err := tree.Collect()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(slots) != 16 {
+			t.Fatalf("expected # of slots to be %v, got %v", 16, len(slots))
+		}
+
+		for i, sc := range m.freeSlotIndexes[0] {
+			if !sc {
+				t.Fatalf("expected the slot to be filled at %v", i)
+			}
+		}
+
+		// let's also assert slots offsets increment by 256
+
+		var prevOffset int64
+		prevOffset = -1
+
+		for i, slot := range slots {
+			if prevOffset == -1 {
+				prevOffset = int64(slot.offset)
+			} else {
+				if uint64(prevOffset)+256 != slot.offset {
+					t.Fatalf("expected offset to be %v, got %v at %v", prevOffset+256, slot.offset, i)
+				}
+			}
+
+			prevOffset = int64(slot.offset)
+		}
+	})
+
+	t.Run("fills up many pages", func(t *testing.T) {
+		buf := buftest.NewSeekableBuffer()
+		pf, err := pagefile.NewPageFile(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		m := New(pf)
+
+		tree, err := NewMultiBPTree(pf, m, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := tree.Reset(); err != nil {
+			t.Fatal(err)
+		}
+
+		N := 200
+
+		prevSlot := tree
+		for i := 1; i < N; i++ { // we start from 1 because tree was technically 0th
+			newSlot, err := prevSlot.AddNext()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			prevSlot = newSlot
+
+			if m.rws.PageCount() != int64(i/16)+1 {
+				t.Fatalf("expect %v pages, got %v at %v", int64(i/16), m.rws.PageCount(), i)
+			}
+		}
+		if m.rws.PageCount() != int64(1+N/16) {
+			t.Fatalf("expect %v pages, got: %v", int64(1+N/16), m.rws.PageCount())
+		}
+
+		if len(m.freeSlotIndexes) != 1+N/16 {
+			t.Fatalf("expected free slot indexes to be of length %v, got %v", 1+N/16, len(m.freeSlotIndexes))
+		}
+
+		var prevOffset int64
+		prevOffset = -1
+
+		slots, err := tree.Collect()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(slots) != N {
+			t.Fatalf("expected # of slots to be %v, got %v", 16, len(slots))
+		}
+
+		for i, slot := range slots {
+			if prevOffset == -1 {
+				prevOffset = int64(slot.offset)
+			} else {
+				if uint64(prevOffset)+256 != slot.offset {
+					t.Fatalf("expected offset to be %v, got %v at %v", prevOffset+256, slot.offset, i)
+				}
+			}
+
+			prevOffset = int64(slot.offset)
+		}
+	})
 }

--- a/pkg/metapage/slot_test.go
+++ b/pkg/metapage/slot_test.go
@@ -60,7 +60,7 @@ func TestMultiBPTree(t *testing.T) {
 		}
 	})
 
-	t.Run("insert a second page", func(t *testing.T) {
+	t.Run("insert a second slot", func(t *testing.T) {
 		b := buftest.NewSeekableBuffer()
 		p, err := pagefile.NewPageFile(b)
 		if err != nil {
@@ -202,7 +202,7 @@ func TestMultiBPTree(t *testing.T) {
 		}
 	})
 
-	t.Run("collect pages", func(t *testing.T) {
+	t.Run("collect slots", func(t *testing.T) {
 		b := buftest.NewSeekableBuffer()
 		p, err := pagefile.NewPageFile(b)
 		if err != nil {
@@ -277,14 +277,17 @@ func TestMultiBPTree(t *testing.T) {
 			currSlot = newSlot
 		}
 
-		// Collect the pages
-		collectedPages, err := slot1.Collect()
+		collectedSlots, err := slot1.Collect()
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(collectedPages) != N {
-			t.Fatalf("expected collected pages to be %v, got %v", N, len(collectedPages))
+		if len(collectedSlots) != N {
+			t.Fatalf("expected collected pages to be %v, got %v", N, len(collectedSlots))
+		}
+
+		if int64(len(collectedSlots)/16+1) != ms.rws.PageCount() {
+			t.Fatalf("expected # of pages to be %v, got %v", len(collectedSlots)/16+1, ms.rws.PageCount())
 		}
 	})
 


### PR DESCRIPTION
Introduces three edge cases:

1) `NewMultiBPTree()` is a somewhat deceiving name. Under the hood, it creates a `LinkedMetaSlot`. We make sure we properly catch for this.

2) Fill 16 slots. After filling up 16 slots, we should make sure the page gets filled, our in-memory `[][]bool` slot checker behaves accordingly, and the # of pages is ideal. Also after adding, we collect the slots, iterate through, and make sure that given ps, ns where ps is the prev slot and ns is the new slot, ps + (slotSize) = ns

3) Fill 200 slots. Checks for the same asserts as the ones above. 