### PR TITLE
feat: store unique pointers for trigrams

### DIFF
--- a/pkg/handlers/jsonl.go
+++ b/pkg/handlers/jsonl.go
@@ -187,10 +187,16 @@ func (j JSONLHandler) handleJSONLObject(f *appendable.IndexFile, r []byte, dec *
 
 					for _, tri := range trigrams {
 						valueBytes := []byte(tri.Word)
-						mp.Offset += tri.Offset
+
+						newMp := pointer.MemoryPointer{
+							Offset: mp.Offset + tri.Offset,
+							Length: mp.Length + tri.Length,
+						}
+
 						mp.Length += tri.Length
+
 						if err := page.BPTree(&btree.BPTree{Data: r, DataParser: j, Width: width}).Insert(btree.ReferencedValue{
-							DataPointer: mp,
+							DataPointer: newMp,
 							Value:       valueBytes,
 						}, data); err != nil {
 							return fmt.Errorf("failed to insert into b+tree: %w", err)

--- a/pkg/handlers/jsonl.go
+++ b/pkg/handlers/jsonl.go
@@ -188,14 +188,12 @@ func (j JSONLHandler) handleJSONLObject(f *appendable.IndexFile, r []byte, dec *
 					for _, tri := range trigrams {
 						valueBytes := []byte(tri.Word)
 
-						newMp := pointer.MemoryPointer{
-							Offset: mp.Offset + tri.Offset,
-							Length: tri.Length,
-						}
-
 						if err := page.BPTree(&btree.BPTree{Data: r, DataParser: j, Width: width}).Insert(btree.ReferencedValue{
-							DataPointer: newMp,
-							Value:       valueBytes,
+							DataPointer: pointer.MemoryPointer{
+								Offset: mp.Offset + tri.Offset,
+								Length: tri.Length,
+							},
+							Value: valueBytes,
 						}, data); err != nil {
 							return fmt.Errorf("failed to insert into b+tree: %w", err)
 						}

--- a/pkg/handlers/jsonl.go
+++ b/pkg/handlers/jsonl.go
@@ -190,10 +190,8 @@ func (j JSONLHandler) handleJSONLObject(f *appendable.IndexFile, r []byte, dec *
 
 						newMp := pointer.MemoryPointer{
 							Offset: mp.Offset + tri.Offset,
-							Length: mp.Length + tri.Length,
+							Length: tri.Length,
 						}
-
-						mp.Length += tri.Length
 
 						if err := page.BPTree(&btree.BPTree{Data: r, DataParser: j, Width: width}).Insert(btree.ReferencedValue{
 							DataPointer: newMp,


### PR DESCRIPTION
When we handle a JSONL object line, we store a memory pointer of the following:

```go
mp := pointer.MemoryPointer{
    Offset: data.Offset + uint64(fieldOffset),
    Length: uint32(dec.InputOffset() - fieldOffset),
}
```

For the trigram case, we split a string into a bunch of trigrams that conveniently store the offset and the holistic length. We need to make sure when we insert the trigram into the btree, we update the memory pointer correctly.

The PR changes the faulty logic, which would iteratively increment the memory pointer's offset + length. However, this doesn't make sense as the offset for that iteration should be added to the offset from the original memory pointer. 

