### PR TITLE
feat: change seek to accept a set of field types to search for

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -110,7 +110,10 @@ export class Database<T extends Schema> {
       const tok = new NgramTokenizer(minGram, maxGram);
 
       const key = query.search.key;
-      const mps = await this.indexFile.seek(key as string, FieldType.Trigram);
+      const mps = await this.indexFile.seek(
+        key as string,
+        new Set<FieldType>([FieldType.Trigram]),
+      );
       const mp = mps[0];
       const { fieldType: mpFieldType, width: mpFieldWidth } =
         await readIndexMeta(await mp.metadata());
@@ -171,7 +174,10 @@ export class Database<T extends Schema> {
         }
         const { fieldType, valueBuf } = res;
 
-        const mps = await this.indexFile.seek(key as string, fieldType);
+        const mps = await this.indexFile.seek(
+          key as string,
+          new Set<FieldType>([fieldType]),
+        );
         const mp = mps[0];
         const { fieldType: mpFieldType, width: mpFieldWidth } =
           await readIndexMeta(await mp.metadata());

--- a/src/file/index-file.ts
+++ b/src/file/index-file.ts
@@ -40,7 +40,7 @@ export interface VersionedIndexFile<T> {
 
   indexHeaders(): Promise<IndexHeader[]>;
 
-  seek(header: string, fieldType: FieldType): Promise<LinkedMetaPage[]>;
+  seek(header: string, fieldTypes: Set<FieldType>): Promise<LinkedMetaPage[]>;
 
   fetchMetaPages(): Promise<void>;
 }
@@ -96,7 +96,10 @@ export class IndexFileV1<T> implements VersionedIndexFile<T> {
     };
   }
 
-  async seek(header: string, fieldType: FieldType): Promise<LinkedMetaPage[]> {
+  async seek(
+    header: string,
+    fieldTypes: Set<FieldType>,
+  ): Promise<LinkedMetaPage[]> {
     if (this.linkedMetaPages.length === 0) {
       await this.fetchMetaPages();
     }
@@ -107,7 +110,7 @@ export class IndexFileV1<T> implements VersionedIndexFile<T> {
       const mp = this.linkedMetaPages[idx];
       const indexMeta = await readIndexMeta(await mp.metadata());
       if (indexMeta.fieldName === header) {
-        if (fieldType === FieldType.Float64) {
+        if (fieldTypes.has(FieldType.Float64)) {
           // if key is a number or bigint, we cast it as a float64 type
           if (
             indexMeta.fieldType === FieldType.Float64 ||
@@ -117,7 +120,7 @@ export class IndexFileV1<T> implements VersionedIndexFile<T> {
             headerMps.push(mp);
           }
         } else {
-          if (indexMeta.fieldType === fieldType) {
+          if (fieldTypes.has(indexMeta.fieldType)) {
             headerMps.push(mp);
           }
         }


### PR DESCRIPTION
Instead of seeking for one field type, `seek()` now does the following:

```
Given a fieldName (header) and a set of FieldTypes, returns a list of meta pages, mp, where mp.FieldName == header && mp.FieldType is contained in the set of FieldTypes.
```