### PR TITLE
feat: update search flow

### DIFF
--- a/src/file/index-file.ts
+++ b/src/file/index-file.ts
@@ -40,7 +40,7 @@ export interface VersionedIndexFile<T> {
 
   indexHeaders(): Promise<IndexHeader[]>;
 
-  seek(header: string, fieldTypes: Set<FieldType>): Promise<LinkedMetaPage[]>;
+  seek(header: string, fieldType: FieldType): Promise<LinkedMetaPage[]>;
 
   fetchMetaPages(): Promise<void>;
 }
@@ -96,10 +96,7 @@ export class IndexFileV1<T> implements VersionedIndexFile<T> {
     };
   }
 
-  async seek(
-    header: string,
-    fieldTypes: Set<FieldType>,
-  ): Promise<LinkedMetaPage[]> {
+  async seek(header: string, fieldType: FieldType): Promise<LinkedMetaPage[]> {
     if (this.linkedMetaPages.length === 0) {
       await this.fetchMetaPages();
     }
@@ -110,7 +107,7 @@ export class IndexFileV1<T> implements VersionedIndexFile<T> {
       const mp = this.linkedMetaPages[idx];
       const indexMeta = await readIndexMeta(await mp.metadata());
       if (indexMeta.fieldName === header) {
-        if (fieldTypes.has(FieldType.Float64)) {
+        if (fieldType === FieldType.Float64) {
           // if key is a number or bigint, we cast it as a float64 type
           if (
             indexMeta.fieldType === FieldType.Float64 ||
@@ -120,7 +117,7 @@ export class IndexFileV1<T> implements VersionedIndexFile<T> {
             headerMps.push(mp);
           }
         } else {
-          if (fieldTypes.has(indexMeta.fieldType)) {
+          if (fieldType === indexMeta.fieldType) {
             headerMps.push(mp);
           }
         }

--- a/src/search/table.ts
+++ b/src/search/table.ts
@@ -1,0 +1,43 @@
+type Entry = { key: string; count: number; _score: number };
+export class NgramTable {
+  private visited: Map<string, number>;
+  private topValue: Entry = { key: "", count: -1, _score: 0.0 };
+
+  constructor() {
+    this.visited = new Map();
+  }
+
+  insert(key: string) {
+    const count = (this.visited.get(key) || 0) + 1;
+
+    if (this.topValue.count < count) {
+      this.topValue = { key, count, _score: 0.0 };
+    }
+
+    this.visited.set(key, count);
+  }
+
+  get(): string | null {
+    const { key, count } = this.topValue;
+
+    if (count < 0) {
+      return null;
+    }
+
+    this.visited.delete(key);
+
+    this.topValue = { key: "", count: -1, _score: 0.0 };
+    for (const [key, count] of this.visited.entries()) {
+      if (count > this.topValue.count) {
+        this.topValue = { key, count, _score: 0.0 };
+      }
+    }
+
+    return key;
+  }
+
+  clear() {
+    this.visited = new Map();
+    this.topValue = { key: "", count: -1, _score: 0.0 };
+  }
+}

--- a/src/util/textEncoder.ts
+++ b/src/util/textEncoder.ts
@@ -1,0 +1,7 @@
+export class QuickTextEncoder {
+  private textEncoder: TextEncoder = new TextEncoder();
+
+  buffer(phrase: string): ArrayBuffer {
+    return this.textEncoder.encode(phrase).buffer;
+  }
+}


### PR DESCRIPTION
Sorry for the large PR. 

## What this PR contains:

- introduce `Unigram` and `Bigram` to ts `FieldType`s
- add `NgramToken` type that encodes the value plus the token gram type
- Update the search flow
Given a phrase to search for, we break it into ngram tokens, shuffle it, then we iterate through. For every ngram type, we keep a btree cache to remove the need for repeating logic. We append the result to the NgramTable, which acts as a "priority queue" and yields the most frequent result


- revert #222 as this is not planned anymore
- a test util function to simplify text encoding -> buffer