### PR TITLE
feat: add ngram token type

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -25,6 +25,8 @@ export enum FieldType {
   Boolean = 6,
   Null = 7,
   Trigram = 8,
+  Bigram = 9,
+  Unigram = 10,
 }
 
 export function fieldTypeToString(f: FieldType): string {
@@ -62,6 +64,12 @@ export function fieldTypeToString(f: FieldType): string {
       break;
     case FieldType.Trigram:
       str = "Trigram";
+      break;
+    case FieldType.Bigram:
+      str = "Bigram";
+      break;
+    case FieldType.Unigram:
+      str = "Unigram";
       break;
   }
   return str;
@@ -132,8 +140,8 @@ export class Database<T extends Schema> {
 
       const trigramTable = new NgramTable();
 
-      for (const tri of likeTrigrams) {
-        const valueBuf = encoder.encode(tri).buffer;
+      for (const tok of likeTrigrams) {
+        const { valueBuf } = tok;
         const valueRef = new ReferencedValue(
           { offset: 0n, length: 0 },
           valueBuf,

--- a/src/search/tokenizer.ts
+++ b/src/search/tokenizer.ts
@@ -45,11 +45,11 @@ export class NgramTokenizer {
     }
 
     for (let N = this.minGram; N <= this.maxGram; N++) {
-      let gType =
-        this.allGrams.get(N) ??
-        (() => {
-          throw new Error(`Unrecognized gram type for gram length: ${N}`);
-        })();
+      const gType = this.allGrams.get(N);
+
+      if (!gType) {
+        throw new Error(`Unrecognized gram type for gram length: ${N}`);
+      }
 
       wordOffsets.forEach((word) => {
         for (let idx = 0; idx <= word.length - N; idx++) {

--- a/src/tests/tokenizer.test.ts
+++ b/src/tests/tokenizer.test.ts
@@ -1,7 +1,13 @@
 import { NgramTable, NgramTokenizer } from "../search/tokenizer";
+import { FieldType } from "../db/database";
 
 describe("builds 12grams", () => {
   let tok: NgramTokenizer;
+  let textEncoder: TextEncoder;
+
+  beforeAll(() => {
+    textEncoder = new TextEncoder();
+  });
 
   beforeEach(() => {
     tok = new NgramTokenizer(1, 2);
@@ -25,7 +31,11 @@ describe("builds 12grams", () => {
       "me",
       "eu",
       "up",
-    ];
+    ].map((s) => ({
+      value: s,
+      valueBuf: textEncoder.encode(s).buffer,
+      type: s.length === 1 ? FieldType.Unigram : FieldType.Bigram,
+    }));
 
     const trigrams = tok.tokens(phrase);
     expect(trigrams).toEqual(expected);
@@ -52,7 +62,11 @@ describe("builds 12grams", () => {
       "ak",
       "ke",
       "up",
-    ];
+    ].map((s) => ({
+      value: s,
+      valueBuf: textEncoder.encode(s).buffer,
+      type: s.length === 1 ? FieldType.Unigram : FieldType.Bigram,
+    }));
 
     const trigrams = tok.tokens(phrase);
     expect(trigrams).toEqual(expected);
@@ -61,6 +75,11 @@ describe("builds 12grams", () => {
 
 describe("builds trigrams", () => {
   let tok: NgramTokenizer;
+  let textEncoder: TextEncoder;
+
+  beforeAll(() => {
+    textEncoder = new TextEncoder();
+  });
 
   beforeEach(() => {
     tok = new NgramTokenizer(3, 3);
@@ -68,7 +87,11 @@ describe("builds trigrams", () => {
 
   it("builds a basic trigram", () => {
     const phrase = "wakemeup";
-    const expected = ["wak", "ake", "kem", "eme", "meu", "eup"];
+    const expected = ["wak", "ake", "kem", "eme", "meu", "eup"].map((s) => ({
+      value: s,
+      valueBuf: textEncoder.encode(s).buffer,
+      type: FieldType.Trigram,
+    }));
 
     const trigrams = tok.tokens(phrase);
     expect(trigrams).toEqual(expected);
@@ -76,7 +99,11 @@ describe("builds trigrams", () => {
 
   it("builds a complex trigram", () => {
     const phrase = "I can't wake up";
-    const expected = ["can", "ant", "wak", "ake"];
+    const expected = ["can", "ant", "wak", "ake"].map((s) => ({
+      value: s,
+      valueBuf: textEncoder.encode(s).buffer,
+      type: FieldType.Trigram,
+    }));
 
     const trigrams = tok.tokens(phrase);
     expect(trigrams).toEqual(expected);


### PR DESCRIPTION
This PR introduces the `NgramToken` type and updates the logic in Tokenizer.

Added a static `TextEncoder` to `Tokenizer()` which will encode each trigram's strings to an ArrayBuffer. It also contains the  ngram token's specific FieldType.Ngram type.