### PR TITLE
feat: add cursor

### DIFF
--- a/src/btree/cursor.ts
+++ b/src/btree/cursor.ts
@@ -1,0 +1,81 @@
+import { BTree, ReferencedValue } from "./btree";
+import { BTreeNode } from "./node";
+
+export class BTreeCursor {
+  private readonly btree: BTree;
+
+  private uniqueEntriesPromise: Promise<number> | null = null;
+
+  constructor(btree: BTree) {
+    this.btree = btree;
+  }
+
+  async first(): Promise<ReferencedValue> {
+    let { rootNode } = await this.btree.root();
+    if (!rootNode) {
+      throw new Error("unable to get root node");
+    }
+
+    let currNode = await this.btree.readNode(rootNode.pointer(0));
+
+    while (!currNode.leaf()) {
+      const childPointer = currNode.pointer(0);
+      currNode = await this.btree.readNode(childPointer);
+    }
+
+    return currNode.keys[0];
+  }
+
+  async last(): Promise<ReferencedValue> {
+    let { rootNode } = await this.btree.root();
+    if (!rootNode) {
+      throw new Error("unable to get root node");
+    }
+
+    let currNode = await this.btree.readNode(
+      rootNode.pointer(rootNode.numPointers() - 1),
+    );
+
+    while (!currNode.leaf()) {
+      const childPointer = currNode.pointer(currNode.numPointers() - 1);
+      currNode = await this.btree.readNode(childPointer);
+    }
+
+    return currNode.keys[currNode.keys.length - 1];
+  }
+
+  // Counts the number of unique entries in the datafile
+  uniqueEntries(): Promise<number> {
+    if (!this.uniqueEntriesPromise) {
+      this.uniqueEntriesPromise = this.computeUniqueLeafs();
+    }
+
+    return this.uniqueEntriesPromise;
+  }
+
+  private async computeUniqueLeafs(): Promise<number> {
+    let { rootNode } = await this.btree.root();
+    if (!rootNode) {
+      return 0;
+    }
+
+    const uniqueOffsets = new Set<bigint>();
+    await this.traverseLeafs(rootNode, uniqueOffsets);
+
+    return uniqueOffsets.size;
+  }
+
+  private async traverseLeafs(node: BTreeNode, uniqueOffsets: Set<bigint>) {
+    if (node.leaf()) {
+      for (const { offset } of node.leafPointers) {
+        uniqueOffsets.add(offset);
+      }
+    } else {
+      for (let idx = 0; idx <= node.numPointers() - 1; idx++) {
+        const childPtr = node.pointer(idx);
+        const childNode = await this.btree.readNode(childPtr);
+        await this.traverseLeafs(childNode, uniqueOffsets);
+      }
+    }
+  }
+}

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -210,6 +210,8 @@ export class Database<T extends Schema> {
           mpFieldWidth,
         );
 
+        const cursor = btree.cursor();
+
         if (operation === ">") {
           if (ord === "ASC") {
             const valueRef = new ReferencedValue(
@@ -229,7 +231,7 @@ export class Database<T extends Schema> {
               yield handleSelect(data, query.select);
             }
           } else {
-            const lastKey = await btree.last();
+            const lastKey = await cursor.last();
             const iter = btree.iter(lastKey);
 
             while (await iter.prev()) {
@@ -269,7 +271,7 @@ export class Database<T extends Schema> {
               yield handleSelect(data, query.select);
             }
           } else {
-            const lastKey = await btree.last();
+            const lastKey = await cursor.last();
             const iter = btree.iter(lastKey);
 
             while (await iter.prev()) {
@@ -338,7 +340,7 @@ export class Database<T extends Schema> {
               yield handleSelect(data, query.select);
             }
           } else {
-            const firstKey = await btree.first();
+            const firstKey = await cursor.first();
             const iter = btree.iter(firstKey);
 
             while (await iter.next()) {
@@ -378,7 +380,7 @@ export class Database<T extends Schema> {
               yield handleSelect(data, query.select);
             }
           } else {
-            const firstKey = await btree.first();
+            const firstKey = await cursor.first();
             const iter = btree.iter(firstKey);
 
             while (await iter.next()) {

--- a/src/tests/btreecursor.test.ts
+++ b/src/tests/btreecursor.test.ts
@@ -1,0 +1,70 @@
+import { BTree, MetaPage } from "../btree/btree";
+import { MemoryPointer } from "../btree/node";
+import { RangeResolver } from "../resolver/resolver";
+import { readBinaryFile } from "./test-util";
+import { FileFormat } from "../file/meta";
+import { FieldType } from "../db/database";
+import { BTreeCursor } from "../btree/cursor";
+
+class testMetaPage implements MetaPage {
+  private readonly rootMP: MemoryPointer;
+
+  constructor(mp: MemoryPointer) {
+    this.rootMP = mp;
+  }
+
+  async root(): Promise<MemoryPointer> {
+    return this.rootMP;
+  }
+}
+
+describe("cursor", () => {
+  let mockRangeResolver: RangeResolver;
+  let mockDataFileResolver: RangeResolver;
+  let btree: BTree;
+  let cursor: BTreeCursor;
+
+  beforeEach(() => {
+    mockDataFileResolver = async ([]) => {
+      return [
+        {
+          data: new ArrayBuffer(0),
+          totalLength: 0,
+        },
+      ];
+    };
+
+    mockRangeResolver = async ([{ start, end }]) => {
+      const indexFile = await readBinaryFile("btree_1023.bin");
+      const slicedPart = indexFile.slice(start, end + 1);
+
+      const arrayBuffer = slicedPart.buffer.slice(
+        slicedPart.byteOffset,
+        slicedPart.byteOffset + slicedPart.byteLength,
+      );
+
+      return [
+        {
+          data: arrayBuffer,
+          totalLength: arrayBuffer.byteLength,
+        },
+      ];
+    };
+
+    const page = new testMetaPage({ offset: 8192n, length: 88 });
+    btree = new BTree(
+      mockRangeResolver,
+      page,
+      mockDataFileResolver,
+      FileFormat.CSV,
+      FieldType.String,
+      9,
+    );
+
+    cursor = btree.cursor();
+  });
+
+  it("fetches the # of elements", async () => {
+    expect(await cursor.uniqueEntries()).toEqual(10);
+  });
+});


### PR DESCRIPTION
A Btree cursor traverses the btree and returns high level information about the btree. 

The difference between this class and the traversal iterator, is that the iterator is stateful, while the Cursor takes a "static" view of the instantiated btree