### PR TITLE
feat: change to one byte for LinkedMetaPage metadata length

### DIFF
--- a/pkg/metapage/multi_test.go
+++ b/pkg/metapage/multi_test.go
@@ -188,10 +188,10 @@ func TestMultiBTree(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := node.SetMetadata(make([]byte, 256)); err != nil {
+		if err := node.SetMetadata(make([]byte, 255)); err != nil {
 			t.Fatal(err)
 		}
-		if err := node.SetMetadata(make([]byte, 257)); err == nil {
+		if err := node.SetMetadata(make([]byte, 256)); err == nil {
 			t.Fatal("expected error")
 		}
 	})


### PR DESCRIPTION
Ref: https://github.com/kevmo314/appendable/pull/250#pullrequestreview-2009507034


This PR allocates 1 byte for the metadata length in `LinkedMetaPage`. The test case is refactored where `255` is the **greatest** possible value


