### PR TITLE
feat: remove fluff

### DIFF
--- a/pkg/metapage/multi.go
+++ b/pkg/metapage/multi.go
@@ -116,7 +116,7 @@ func (m *LinkedMetaPage) Metadata() ([]byte, error) {
 	if m.index == ^uint8(0) {
 		return nil, errNotAPage
 	}
-	if _, err := m.rws.Seek(int64(m.rootMemoryPointerPageOffset())+24, io.SeekStart); err != nil {
+	if _, err := m.rws.Seek(int64(m.rootMemoryPointerPageOffset()+pointerBytes+4), io.SeekStart); err != nil {
 		return nil, err
 	}
 	buf := make([]byte, 4+m.rws.SlotSize())
@@ -143,7 +143,7 @@ func (m *LinkedMetaPage) SetMetadata(data []byte) error {
 	if len(data) > m.rws.SlotSize() || len(data) > 255 {
 		return errors.New("metadata too large")
 	}
-	if _, err := m.rws.Seek(int64(m.rootMemoryPointerPageOffset())+24, io.SeekStart); err != nil {
+	if _, err := m.rws.Seek(int64(m.rootMemoryPointerPageOffset()+pointerBytes+4), io.SeekStart); err != nil {
 		return err
 	}
 	buf := append(make([]byte, 1), data...)


### PR DESCRIPTION
Currently our hex looks like: `<next ptr: 8 bytes><count: 1 byte><root ptr: 12 bytes><???: 12 bytes><metadata>`, we need to get rid of the ???. This PR does this by changing how much we seek by.

<img width="718" alt="Screen Shot 2024-04-22 at 2 12 31 PM" src="https://github.com/kevmo314/appendable/assets/38759997/0321b0a6-bf6c-4e63-b7ab-12f507054345">
