### PR TITLE
fix: assertions

### DIFF
--- a/pkg/metapage/multi_test.go
+++ b/pkg/metapage/multi_test.go
@@ -253,7 +253,7 @@ func TestMultiBTree(t *testing.T) {
 
 		for i, slot := range pages {
 			if i == 0 {
-				if slot.offset != 4096 && slot.rootMemoryPointerPageOffset() != 4096+13 {
+				if slot.offset != 4096 || slot.rootMemoryPointerPageOffset() != 4096+pointerBytes+countByte {
 					t.Fatalf("expected initial slot offset to start at 4096, got: %v", slot.rootMemoryPointerPageOffset())
 				}
 
@@ -298,7 +298,7 @@ func TestMultiBTree(t *testing.T) {
 
 		for i, slot := range pages {
 			if i == 0 {
-				if slot.offset != 4096 && slot.rootMemoryPointerPageOffset() != 4096+13 {
+				if slot.offset != 4096 || slot.rootMemoryPointerPageOffset() != 4096+pointerBytes+countByte {
 					t.Fatalf("expected initial slot offset to start at 4096, got: %v", slot.rootMemoryPointerPageOffset())
 				}
 
@@ -307,7 +307,7 @@ func TestMultiBTree(t *testing.T) {
 			}
 
 			if i == 15 {
-				if slot.offset != 4096*2 && slot.rootMemoryPointerPageOffset() != 4096*2+13 {
+				if slot.offset != 4096*2 || slot.rootMemoryPointerPageOffset() != 4096*2+pointerBytes+countByte {
 					t.Fatalf("expected initial slot offset to start at 4096, got: %v", slot.rootMemoryPointerPageOffset())
 				}
 


### PR DESCRIPTION
The `metapage` test cases assert the correctness of the slot offsets for a given N entries. 