### PR TITLE
DNM: Show field headers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -124,6 +124,13 @@ func main() {
 		panic(err)
 	}
 
+	fn, err := i.IndexFieldNames()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("\nfield names: %v\n", fn)
+
 	if showTimings {
 		readDuration := time.Since(readStart)
 		logger.Info("Opening + synchronizing index file took", slog.Duration("duration", readDuration))

--- a/pkg/metapage/multi_test.go
+++ b/pkg/metapage/multi_test.go
@@ -294,6 +294,10 @@ func TestMultiBTree(t *testing.T) {
 
 		pages, err := tree.Collect()
 
+		if len(pages) != n {
+			t.Fatalf("expected num pages to be %v, got %v", n, len(pages))
+		}
+
 		prevOffset := uint64(0)
 
 		for i, slot := range pages {


### PR DESCRIPTION
It seems like the index file stores all of the index field names.


<img width="809" alt="Screen Shot 2024-04-23 at 10 03 31 AM" src="https://github.com/kevmo314/appendable/assets/38759997/d0b61700-89b7-4557-89a0-a8c0949b45c5">


However, upon looking at the hex editor, it seems like they are scattered 