### PR TITLE
feat: rename pointers and update traversal logic

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -196,8 +196,9 @@ export class Database<T extends Schema> {
 
         const mps = await this.indexFile.seek(key as string, fieldType);
         const mp = mps[0];
-        const { fieldType: mpFieldType, width: mpFieldWidth } =
-          await readIndexMeta(await mp.metadata());
+        const { fieldType: mpFieldType, width: mpFieldWidth } = readIndexMeta(
+          await mp.metadata(),
+        );
 
         let ord: "ASC" | "DESC" = "ASC";
         if (query.orderBy && query.orderBy[0]) {

--- a/src/file/multi.ts
+++ b/src/file/multi.ts
@@ -24,7 +24,7 @@ export class LinkedMetaPage {
     const pageData = await this.getMetaPage();
 
     // we seek by 12 bytes since offset is 8 bytes, length is 4 bytes
-    const data = pageData.slice(0, 12);
+    const data = pageData.slice(0, POINTER_BYTES + LENGTH_BYTES);
     const view = new DataView(data);
 
     const pointerOffset = view.getBigUint64(0, true);
@@ -72,7 +72,7 @@ export class LinkedMetaPage {
     const pageData = await this.getMetaPage();
     const view = new DataView(pageData);
 
-    const count = view.getUint8(12);
+    const count = view.getUint8(POINTER_BYTES);
 
     if (this.index < count - 1) {
       return new LinkedMetaPage(


### PR DESCRIPTION
This PR contains two things:
1. The root pointer (`POINTER_BYTE`) is 8 bytes long. 
2. The first slot, that is `tree.metadata()` is the `FileMeta`. Before we traverse through pages, we need to peel the head. 