### PR TITLE
feat: fix ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ pprof.out
 examples/**/appendable.min.js
 examples/**/appendable.min.js.map
 
+# But include the palo-alto dataset
+!examples/workspace/palo-alto.jsonl
+
 # But include these files in src/tests/mock_binaries
 !src/tests/mock_binaries/*.jsonl
 !src/tests/mock_binaries/*.cs


### PR DESCRIPTION
CI broke because since the `search` dataset is derived from git tracing, not from a python script