### PR TITLE
feat: link

### DIFF
--- a/pkg/hnsw/hnsw.go
+++ b/pkg/hnsw/hnsw.go
@@ -113,7 +113,10 @@ func (h *Hnsw) searchLayer(q Vector, entryNode *Node, ef int, layerId int) *MinQ
 		if len(h.Nodes[closestCandidate.id].friends) >= layerId+1 {
 			friends := h.Nodes[closestCandidate.id].friends[layerId]
 
-			for _, friendId := range friends {
+			for !friends.IsEmpty() {
+				friend := friends.Peel()
+				friendId := friend.id
+
 				// if friendId ∉ visitor
 				if !visited[friendId] {
 					visited[friendId] = true
@@ -190,4 +193,14 @@ func (h *Hnsw) KnnSearch(q Vector, kNeighborsToReturn, ef int) ([]*Item, error) 
 	}
 
 	return currentNearestElements.Take(kNeighborsToReturn)
+}
+
+func (h *Hnsw) Link(i0, i1 *Item, level int) {
+	n0, n1 := h.Nodes[i0.id], h.Nodes[i1.id]
+	f0, f1 := n0.friends, n1.friends
+
+	mq0, mq1 := f0[level], f1[level]
+
+	mq0.Insert(i1.id, i1.dist)
+	mq1.Insert(i0.id, i0.dist)
 }

--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -12,3 +12,72 @@ func TestHnsw(t *testing.T) {
 		}
 	})
 }
+
+func TestHnsw_Link(t *testing.T) {
+	t.Run("links correctly", func(t *testing.T) {
+
+		mq1 := make(map[int]*MinQueue)
+		mq1[0] = NewMinQueue()
+		mq1[1] = NewMinQueue()
+		mq1[2] = NewMinQueue()
+
+		mq2 := make(map[int]*MinQueue)
+		mq2[0] = NewMinQueue()
+		mq2[1] = NewMinQueue()
+
+		n1 := Node{
+			id:      1,
+			v:       make(Vector, 128),
+			layer:   3,
+			friends: mq1,
+		}
+
+		n2 := Node{
+			id:      2,
+			v:       make(Vector, 128),
+			layer:   0,
+			friends: mq2,
+		}
+
+		p := make(Vector, 128)
+		h := NewHNSW(128, 4, 200, NewNode(0, p))
+
+		h.Nodes[1] = &n1
+		h.Nodes[2] = &n2
+
+		i1 := Item{id: 1, dist: 3}
+		i2 := Item{id: 2, dist: 49}
+
+		// now h has enuogh context to test Linking
+
+		if h.Nodes[1].friends[1].Len() != 0 {
+			t.Fatalf("expected n1's num friends at level 1 to be 0, got %v", h.Nodes[1].friends[1].Len())
+		}
+
+		if h.Nodes[2].friends[1].Len() != 0 {
+			t.Fatalf("expected n2's num friends at level 1 to be 0, got %v", h.Nodes[1].friends[1].Len())
+		}
+
+		h.Link(&i1, &i2, 1)
+
+		// i1 should be friends with i2
+		// i2 should be friends with i1
+
+		if h.Nodes[1].friends[1].Len() != 1 {
+			t.Fatalf("expected n1's num friends at level 1 to be 1, got %v", h.Nodes[1].friends[1].Len())
+		}
+
+		if h.Nodes[2].friends[1].Len() != 1 {
+			t.Fatalf("expected n2's num friends at level 1 to be 1, got %v", h.Nodes[1].friends[1].Len())
+		}
+
+		if h.Nodes[1].friends[1].Peel().id != 2 {
+			t.Fatalf("expected n1 to be friends with n2 at level 1")
+		}
+
+		if h.Nodes[2].friends[1].Peel().id != 1 {
+			t.Fatalf("expected n1 to be friends with n1 at level 1")
+		}
+
+	})
+}

--- a/pkg/hnsw/node.go
+++ b/pkg/hnsw/node.go
@@ -15,7 +15,7 @@ type Node struct {
 	layer int
 
 	// for every layer, we have a list of friends' NodeIds
-	friends [][]NodeId
+	friends map[int]*MinQueue
 }
 
 func NewNode(id NodeId, v Vector) *Node {
@@ -23,7 +23,7 @@ func NewNode(id NodeId, v Vector) *Node {
 		id,
 		v,
 		-1,
-		make([][]NodeId, 0),
+		make(map[int]*MinQueue),
 	}
 }
 


### PR DESCRIPTION
When you insert a vector, we need to establish bidirectional connection between our neighbors and the current node.

This PR contains Link. Please note, we also refactored the `Node`'s `friends` class to be a map of minqueues 