### PR TITLE
Inserting the first vector after the entry node

### DIFF
--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -120,6 +120,18 @@ func TestHnsw_Insert(t *testing.T) {
 		}
 	})
 
+	t.Run("verify insert", func(t *testing.T) {
+		h := NewHNSW(2000, 32, 32, NewNode(0, []float64{1, 1, 1}, 10))
+
+		if h.MaxLayer != 10 {
+			t.Fatalf("expected max layer to be set greater than 0, but got %v", h.MaxLayer)
+		}
+
+		if err := h.Insert([]float64{3, 3, 3}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
 }
 
 func TestHnsw_Link(t *testing.T) {


### PR DESCRIPTION
A hnsw is guaranteed to have an entry node, that is a graph will never have zero vectors.

The insert `vector q` function iterates through the layers and finds the closest nearest neighbor. Note, the parameter explicitly states to find 1 neighbor.

The problem occurs in `searchLayer` line 114 where we iterate through candidates. The only candidate should be the entry node, but entry nodes don't have any friends at any levels!

Maybe I missed a part where an entry node should be friends with everyone, but I couldn't find that in the algorithm