### PR TITLE
feat: check level inbound and consistent naming

### DIFF
--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -10,8 +10,8 @@ func TestHnsw(t *testing.T) {
 		n := NewNode(0, []float64{0.1, 0.2}, 3)
 		h := NewHNSW(20, 32, 32, n)
 
-		if h.MaxLayer != -1 {
-			t.Fatalf("expected max layer to default to -1, got %v", h.MaxLayer)
+		if h.MaxLevel != -1 {
+			t.Fatalf("expected max level to default to -1, got %v", h.MaxLevel)
 		}
 	})
 }
@@ -137,14 +137,14 @@ func TestHnsw_Link(t *testing.T) {
 		n1 := Node{
 			id:      1,
 			v:       make(Vector, 128),
-			layer:   3,
+			level:   3,
 			friends: mq1,
 		}
 
 		n2 := Node{
 			id:      2,
 			v:       make(Vector, 128),
-			layer:   0,
+			level:   0,
 			friends: mq2,
 		}
 
@@ -220,7 +220,7 @@ func TestHnsw_Link(t *testing.T) {
 			}
 		}
 
-		// add some friends for qnode at layer 2
+		// add some friends for qnode at level 2
 		qNode.InsertFriendsAtLevel(2, 2, qNode.VecDistFromNode(h.Nodes[2]))
 		qNode.InsertFriendsAtLevel(2, 3, qNode.VecDistFromNode(h.Nodes[3]))
 		qNode.InsertFriendsAtLevel(2, 4, qNode.VecDistFromNode(h.Nodes[4]))

--- a/pkg/hnsw/node.go
+++ b/pkg/hnsw/node.go
@@ -12,17 +12,17 @@ type Node struct {
 	id NodeId
 	v  Vector
 
-	layer int
+	level int
 
-	// for every layer, we have a list of friends' NodeIds
+	// for every level, we have a list of friends' NodeIds
 	friends map[int]*BaseQueue
 }
 
-func NewNode(id NodeId, v Vector, layer int) *Node {
+func NewNode(id NodeId, v Vector, level int) *Node {
 	return &Node{
 		id,
 		v,
-		layer,
+		level,
 		make(map[int]*BaseQueue),
 	}
 }
@@ -37,6 +37,14 @@ func (n *Node) InsertFriendsAtLevel(level int, id NodeId, dist float64) {
 	bq := NewBaseQueue(MinComparator{})
 	bq.Insert(id, dist)
 	n.friends[level] = bq
+}
+
+func (n *Node) HasLevel(level int) bool {
+	if level < 0 {
+		panic("level cannot be negative")
+	}
+
+	return len(n.friends)-1 >= level
 }
 
 func (n *Node) GetFriendsAtLevel(level int) *BaseQueue {

--- a/pkg/hnsw/node_test.go
+++ b/pkg/hnsw/node_test.go
@@ -5,6 +5,26 @@ import (
 	"testing"
 )
 
+func TestWithinLevels(t *testing.T) {
+	t.Run("levels are in bounds", func(t *testing.T) {
+		n := NewNode(3, []float64{3, 6, 9}, 3)
+
+		n.friends[0] = NewBaseQueue(MinComparator{})
+		n.friends[1] = NewBaseQueue(MinComparator{})
+		n.friends[2] = NewBaseQueue(MinComparator{})
+
+		for i := 0; i < 3; i++ {
+			if !n.HasLevel(i) {
+				t.Fatalf("since n's max level is %v, all levels less should be true", n.level)
+			}
+		}
+
+		if n.HasLevel(3 + 1) {
+			t.Fatalf("since n's max level is %v, levels greater is not in bounds", n.level)
+		}
+	})
+}
+
 func TestVec(t *testing.T) {
 
 	type t_case struct {


### PR DESCRIPTION
For a given `Node`, the # of keys in `friends` dictate the # of level they have. Note the level to search for is 0-indexed.

Since both `layers` and `levels` were used, stuck with `level`