### PR TITLE
feat: find correct entry node

### DIFF
--- a/pkg/hnsw/eucqueue.go
+++ b/pkg/hnsw/eucqueue.go
@@ -47,16 +47,6 @@ type BaseQueue struct {
 	comparator Comparator
 }
 
-func (bq *BaseQueue) Clone() *BaseQueue {
-	nq := NewBaseQueue(bq.comparator)
-
-	for _, i := range bq.items {
-		nq.Insert(i.id, i.dist)
-	}
-	heap.Init(bq)
-	return nq
-}
-
 func (bq *BaseQueue) Take(count int, comparator Comparator) (*BaseQueue, error) {
 	if len(bq.items) < count {
 		return nil, fmt.Errorf("queue only has %v items, but want to take %v", len(bq.items), count)

--- a/pkg/hnsw/eucqueue.go
+++ b/pkg/hnsw/eucqueue.go
@@ -47,6 +47,16 @@ type BaseQueue struct {
 	comparator Comparator
 }
 
+func (bq *BaseQueue) Clone() *BaseQueue {
+	nq := NewBaseQueue(bq.comparator)
+
+	for _, i := range bq.items {
+		nq.Insert(i.id, i.dist)
+	}
+	heap.Init(bq)
+	return nq
+}
+
 func (bq *BaseQueue) Take(count int, comparator Comparator) (*BaseQueue, error) {
 	if len(bq.items) < count {
 		return nil, fmt.Errorf("queue only has %v items, but want to take %v", len(bq.items), count)
@@ -109,8 +119,8 @@ func (bq *BaseQueue) Pop() any {
 	return item
 }
 
-func (pq *BaseQueue) Less(i, j int) bool {
-	return pq.comparator.Less(pq.items[i], pq.items[j])
+func (bq *BaseQueue) Less(i, j int) bool {
+	return bq.comparator.Less(bq.items[i], bq.items[j])
 }
 
 func (bq *BaseQueue) Insert(id NodeId, dist float64) {

--- a/pkg/hnsw/hnsw.go
+++ b/pkg/hnsw/hnsw.go
@@ -68,7 +68,6 @@ func (h *Hnsw) spawnLevel() uint {
 	return uint(math.Floor(-math.Log(rand.Float64() * h.levelMultiplier)))
 }
 
-
 func (h *Hnsw) searchLevel(q Vector, entryNodeItem *Item, ef int, levelId uint) (*BaseQueue, error) {
 	// visited is a bitset that keeps track of all nodes that have been visited.
 	// we know the size of visited will never exceed len(h.Nodes)
@@ -205,19 +204,18 @@ func (h *Hnsw) Link(friendItem *Item, node *Node, level uint) {
 	}
 }
 
-func (h *Hnsw) findCloserEntryPoint(ep *Item, q Vector, qLevel int) *Item {
-	for level := h.Nodes[h.EntryNodeId].level; level > qLevel; level-- {
+func (h *Hnsw) findCloserEntryPoint(ep *Item, q Vector, qLevel uint) *Item {
+	for level := h.MaxLevel; level > qLevel; level-- {
 		friends := h.Nodes[ep.id].GetFriendsAtLevel(level)
-		fmt.Printf("\nlevel: %v: friends: %v\n", level, friends.Len())
-		for !friends.IsEmpty() {
-			friend, _ := friends.Peel()
+
+		for _, friend := range friends.items {
 			friendDist := h.Nodes[friend.id].VecDistFromVec(q)
+
 			if friendDist < ep.dist {
 				ep = &Item{id: friend.id, dist: friend.dist}
 			}
 		}
 	}
-
 	return ep
 }
 

--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -1,7 +1,6 @@
 package hnsw
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -108,8 +107,6 @@ func TestHnsw_Insert(t *testing.T) {
 		if len(h.Nodes) != 2 {
 			t.Fatalf("expected 2 nodes after insertion but got %v", len(h.Nodes))
 		}
-
-		fmt.Printf("new node %v", h.Nodes[1])
 
 		if h.Nodes[1].id != 1 {
 			t.Fatalf("expected node id at 1 to be initialized but got %v", h.Nodes[1].id)
@@ -267,7 +264,7 @@ func TestFindCloserEntryPoint(t *testing.T) {
 		m := NewNode(1, []float64{5, 5}, 9)
 		h.Nodes[m.id] = m
 
-		for level := 0; level <= 9; level++ {
+		for level := uint(0); level <= 9; level++ {
 			ep.InsertFriendsAtLevel(level, m.id, m.VecDistFromVec(q))
 		}
 
@@ -288,21 +285,36 @@ func TestFindCloserEntryPoint(t *testing.T) {
 		h := NewHNSW(10, 32, 32, ep)
 
 		q := []float64{6, 6}
-		qLayer := 3
+		qLayer := uint(3)
 
 		// suppose we had m := []float{5, 5}. It is closer to q, so let's add m to the friends of ep
 		m := NewNode(1, []float64{5, 5}, 9)
 		h.Nodes[m.id] = m
 		mDist := m.VecDistFromVec(q)
-		for level := 9; level > qLayer; level-- {
-			fmt.Printf("level: %v", level)
-			h.Nodes[h.EntryNodeId].InsertFriendsAtLevel(level, m.id, mDist)
+
+		h.Link(&Item{id: m.id, dist: mDist}, h.Nodes[h.EntryNodeId], m.level)
+
+		n := NewNode(2, []float64{6.1, 6.1}, 4)
+		h.Nodes[n.id] = n
+		nDist := n.VecDistFromNode(m)
+		h.Link(&Item{id: n.id, dist: nDist}, m, n.level)
+
+		// verify for entry node's friends
+		friends := h.Nodes[h.EntryNodeId].friends
+		if friends[9].IsEmpty() {
+			t.Fatalf("expected friends to not be empty at level 4, got %v", friends[4].Len())
+		}
+		if friends[9].Peek().id != 1 {
+			t.Fatalf("expected friend id at level 9 to be %v, got %v", 1, friends[9].Peek().id)
 		}
 
-		// if q layer is 3, then the last layer to check is 3 + 1
-		n := NewNode(2, []float64{6.1, 6.1}, 4)
-		for level := 4; level > qLayer; level-- {
-			h.Nodes[h.EntryNodeId].InsertFriendsAtLevel(level, n.id, n.VecDistFromVec(q))
+		nextFriends := h.Nodes[1].friends
+		if nextFriends[4].IsEmpty() {
+			t.Fatalf("expected friends to not be empty at level 4, got %v", friends[4].Len())
+		}
+
+		if nextFriends[4].Peek().id != 2 {
+			t.Fatalf("expected friend id at level 4 to be %v, got %v", 2, friends[4].Peek().id)
 		}
 
 		epItem := &Item{id: 0, dist: ep.VecDistFromVec(q)}

--- a/pkg/hnsw/node.go
+++ b/pkg/hnsw/node.go
@@ -35,7 +35,6 @@ func NewNode(id NodeId, v Vector, level uint) *Node {
 	}
 }
 
-
 // Must assert with HasLevel first
 func (n *Node) InsertFriendsAtLevel(level uint, id NodeId, dist float64) {
 	n.friends[int(level)].Insert(id, dist)
@@ -80,7 +79,7 @@ func EuclidDist(v0, v1 Vector) float64 {
 		sum += delta * delta
 	}
 
-	return sum
+	return math.Sqrt(sum)
 }
 
 // NearlyEqual is sourced from scalar package written by gonum

--- a/pkg/hnsw/node.go
+++ b/pkg/hnsw/node.go
@@ -28,15 +28,17 @@ func NewNode(id NodeId, v Vector, level int) *Node {
 }
 
 func (n *Node) InsertFriendsAtLevel(level int, id NodeId, dist float64) {
+	if n.friends == nil {
+		n.friends = make(map[int]*BaseQueue)
+	}
 
 	if bq, ok := n.friends[level]; ok {
 		bq.Insert(id, dist)
-		return
+	} else {
+		bq := NewBaseQueue(MinComparator{})
+		bq.Insert(id, dist)
+		n.friends[level] = bq
 	}
-
-	bq := NewBaseQueue(MinComparator{})
-	bq.Insert(id, dist)
-	n.friends[level] = bq
 }
 
 func (n *Node) HasLevel(level int) bool {
@@ -83,7 +85,7 @@ func EuclidDist(v0, v1 Vector) float64 {
 		sum += delta * delta
 	}
 
-	return math.Sqrt(sum)
+	return sum
 }
 
 // NearlyEqual is sourced from scalar package written by gonum


### PR DESCRIPTION
For `Insert` and `KNNSearch`, we need to traverse from the top layer .... qLayer (not included) and find the correct entry node. 

The correct entry node is the node who's max layer is greater than qLayer and is most closest to q amongst the entry node friends