### PR TITLE
quick feat: increment next-node-id

### DIFF
--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -7,7 +7,7 @@ import (
 func TestHnsw(t *testing.T) {
 	t.Run("builds graph", func(t *testing.T) {
 		n := NewNode(0, []float64{0.1, 0.2}, 3)
-		h := NewHNSW(20, 32, 32, n)
+		h := NewHNSW(32, 32, n)
 
 		if h.MaxLevel != n.level {
 			t.Fatalf("expected max level to default to %v, got %v", n.level, h.MaxLevel)
@@ -32,7 +32,7 @@ func TestHnswSelect(t *testing.T) {
 			{id: 11, dist: 20},
 		}, MinComparator{})
 
-		h := NewHNSW(2, 32, 1, NewNode(0, []float64{0, 0}, 3))
+		h := NewHNSW(32, 1, NewNode(0, []float64{0, 0}, 3))
 
 		cn, err := h.selectNeighbors(candidates, 10)
 
@@ -67,7 +67,7 @@ func TestHnswSelect(t *testing.T) {
 			{id: 3, dist: 8},
 		}, MinComparator{})
 
-		h := NewHNSW(2, 32, 1, NewNode(0, []float64{0, 0}, 3))
+		h := NewHNSW(32, 1, NewNode(0, []float64{0, 0}, 3))
 
 		_, err := h.selectNeighbors(candidates, 10)
 		if err == nil {
@@ -80,7 +80,7 @@ func TestHnsw_Insert(t *testing.T) {
 
 	t.Run("nodes[0] is root", func(t *testing.T) {
 		n := NewNode(0, []float64{11, 11}, 3)
-		h := NewHNSW(2000, 32, 32, n)
+		h := NewHNSW(32, 32, n)
 
 		if len(h.Nodes) != 1 {
 			t.Fatalf("hnsw should be initialized with root node but got len: %v", len(h.Nodes))
@@ -93,7 +93,7 @@ func TestHnsw_Insert(t *testing.T) {
 
 	t.Run("hnsw with inserted element q", func(t *testing.T) {
 		entryNode := NewNode(0, []float64{1, 1, 1}, 3)
-		h := NewHNSW(3, 32, 32, entryNode)
+		h := NewHNSW(32, 32, entryNode)
 
 		if len(h.Nodes) != 1 {
 			t.Fatalf("hnsw should be initialized with root node but got len: %v", len(h.Nodes))
@@ -126,7 +126,7 @@ func TestHnsw_Link(t *testing.T) {
 		n2 := NewNode(2, make(Vector, 128), 0)
 
 		p := make(Vector, 128)
-		h := NewHNSW(128, 4, 200, NewNode(0, p, 3))
+		h := NewHNSW(4, 200, NewNode(0, p, 3))
 
 		h.Nodes[1] = n1
 		h.Nodes[2] = n2
@@ -173,7 +173,7 @@ func TestHnsw_Link(t *testing.T) {
 	t.Run("links correctly 2", func(t *testing.T) {
 		qNode := NewNode(1, []float64{4, 4}, 3)
 
-		h := NewHNSW(2, 1, 23, NewNode(0, []float64{0, 0}, 10))
+		h := NewHNSW(1, 23, NewNode(0, []float64{0, 0}, 10))
 
 		h.Nodes[qNode.id] = qNode
 
@@ -237,10 +237,23 @@ func TestHnsw_Link(t *testing.T) {
 	})
 }
 
+func TestNextNodeId(t *testing.T) {
+	t.Run("generate next node", func(t *testing.T) {
+		h := NewHNSW(30, 30, NewNode(0, []float64{}, 1))
+		for i := 0; i <= 100; i++ {
+			nextNodeId := h.getNextNodeId()
+
+			if nextNodeId != NodeId(i+1) {
+				t.Fatalf("expected %v, got %v", i+1, nextNodeId)
+			}
+		}
+	})
+}
+
 func TestFindCloserEntryPoint(t *testing.T) {
 	t.Run("find nothing closer", func(t *testing.T) {
 		epNode := NewNode(0, []float64{0, 0}, 10)
-		h := NewHNSW(10, 32, 32, epNode)
+		h := NewHNSW(32, 32, epNode)
 
 		qVector := []float64{6, 6}
 		qLevel := h.spawnLevel()
@@ -255,7 +268,7 @@ func TestFindCloserEntryPoint(t *testing.T) {
 
 	t.Run("finds something closer traverse all layers", func(t *testing.T) {
 		ep := NewNode(0, []float64{0, 0}, 10)
-		h := NewHNSW(10, 32, 32, ep)
+		h := NewHNSW(32, 32, ep)
 
 		q := []float64{6, 6}
 
@@ -282,7 +295,7 @@ func TestFindCloserEntryPoint(t *testing.T) {
 
 	t.Run("finds something closer during the insertion context", func(t *testing.T) {
 		ep := NewNode(0, []float64{0, 0}, 10)
-		h := NewHNSW(10, 32, 32, ep)
+		h := NewHNSW(32, 32, ep)
 
 		q := []float64{6, 6}
 		qLayer := uint(3)

--- a/pkg/hnsw/node.go
+++ b/pkg/hnsw/node.go
@@ -18,7 +18,6 @@ type Node struct {
 	friends []*BaseQueue
 }
 
-// level is 0-indexed!
 func NewNode(id NodeId, v Vector, level uint) *Node {
 
 	friends := make([]*BaseQueue, level+1)

--- a/pkg/hnsw/node_test.go
+++ b/pkg/hnsw/node_test.go
@@ -86,7 +86,7 @@ func TestVec(t *testing.T) {
 
 func TestNodeFriends(t *testing.T) {
 	t.Run("initialized with correct # of levels", func(t *testing.T) {
-		h := NewHNSW(20, 32, 32, NewNode(0, []float64{3, 4}, 8))
+		h := NewHNSW(32, 32, NewNode(0, []float64{3, 4}, 8))
 		qLayer := h.spawnLevel()
 		qNode := NewNode(1, []float64{3, 1}, qLayer)
 


### PR DESCRIPTION
`NodeId` must be unique, and instead of manually incrementing the next node id upon insertion, we can atomically increment.

Also: removed fluff and extra parameters.

