### PR TITLE
feat: iterate properly @ 3rd pass in `Insert`

### DIFF
--- a/pkg/hnsw/hnsw.go
+++ b/pkg/hnsw/hnsw.go
@@ -13,7 +13,7 @@ type Hnsw struct {
 	EntryNodeId NodeId
 	NextNodeId  NodeId
 
-	MaxLevel uint
+	MaxLevel int
 
 	// default number of connections
 	M int
@@ -52,11 +52,11 @@ func (h *Hnsw) getNextNodeId() NodeId {
 	return atomic.AddUint32(&h.NextNodeId, 1) - 1
 }
 
-func (h *Hnsw) spawnLevel() uint {
-	return uint(math.Floor(-math.Log(rand.Float64() * h.levelMultiplier)))
+func (h *Hnsw) spawnLevel() int {
+	return int(math.Floor(-math.Log(rand.Float64() * h.levelMultiplier)))
 }
 
-func (h *Hnsw) searchLevel(q Vector, entryNodeItem *Item, ef int, levelId uint) (*BaseQueue, error) {
+func (h *Hnsw) searchLevel(q Vector, entryNodeItem *Item, ef int, levelId int) (*BaseQueue, error) {
 	// visited is a bitset that keeps track of all nodes that have been visited.
 	// we know the size of visited will never exceed len(h.Nodes)
 	visited := make([]bool, len(h.Nodes))
@@ -86,54 +86,47 @@ func (h *Hnsw) searchLevel(q Vector, entryNodeItem *Item, ef int, levelId uint) 
 			return nil, err
 		}
 
-		closestCandidateToQDist := EuclidDist(h.Nodes[closestCandidate.id].v, q)
-		furthestNNToQDist := EuclidDist(h.Nodes[furthestNN.id].v, q)
+		closestCandidateToQDist := closestCandidate.dist
+		furthestNNToQDist := furthestNN.dist
 
 		if closestCandidateToQDist > furthestNNToQDist {
 			// all elements in W are evaluated
 			break
 		}
 
-		friends := h.Nodes[closestCandidate.id].GetFriendsAtLevel(levelId)
+		if h.Nodes[closestCandidate.id].HasLevel(levelId) {
+			friends := h.Nodes[closestCandidate.id].GetFriendsAtLevel(levelId)
 
-		for !friends.IsEmpty() {
-			friend, err := friends.Peel()
-			if err != nil {
-				return nil, err
-			}
-			friendId := friend.id
+			for _, friend := range friends.items {
+				friendId := friend.id
 
-			// if friendId ∉ visitor
-			if !visited[friendId] {
-				visited[friendId] = true
-				furthestNNItem := nearestNeighborsToQForEf.Peek()
+				if !visited[friendId] {
+					visited[friendId] = true
+					furthestNNItem := nearestNeighborsToQForEf.Peek()
 
-				friendToQDist := EuclidDist(h.Nodes[friendId].v, q)
-				furthestNNToQDist := EuclidDist(h.Nodes[furthestNNItem.id].v, q)
+					friendToQDist := EuclidDist(h.Nodes[friendId].v, q)
 
-				if friendToQDist < furthestNNToQDist || nearestNeighborsToQForEf.Len() < ef {
-					candidates.Insert(friendId, friendToQDist)
-					nearestNeighborsToQForEf.Insert(friendId, friendToQDist)
-
-					if nearestNeighborsToQForEf.Len() > ef {
+					if nearestNeighborsToQForEf.Len() < ef {
+						nearestNeighborsToQForEf.Insert(friendId, friendToQDist)
+						candidates.Insert(friendId, friendToQDist)
+					} else if friendToQDist < furthestNNItem.dist {
 						nearestNeighborsToQForEf.Pop()
+						nearestNeighborsToQForEf.Insert(friendId, friendToQDist)
+						candidates.Insert(friendId, friendToQDist)
 					}
+
+					return nearestNeighborsToQForEf, nil
 				}
 			}
 		}
 	}
 
-	numNearestToQ, err := nearestNeighborsToQForEf.Take(ef, MinComparator{})
-	if err != nil {
-		return nil, err
-	}
-
-	return numNearestToQ, nil
+	return nearestNeighborsToQForEf, nil
 }
 
 func (h *Hnsw) selectNeighbors(candidates *BaseQueue, numNeighborsToReturn int) (*BaseQueue, error) {
 	if candidates.Len() <= numNeighborsToReturn {
-		return nil, fmt.Errorf("num neighbors to return is %v but candidates len is only %v", numNeighborsToReturn, candidates.Len())
+		return candidates, nil
 	}
 
 	pq, err := candidates.Take(numNeighborsToReturn, MinComparator{})
@@ -176,7 +169,7 @@ func (h *Hnsw) KnnSearch(q Vector, kNeighborsToReturn, ef int) ([]*Item, error) 
 	return pq.items, nil
 }
 
-func (h *Hnsw) Link(friendItem *Item, node *Node, level uint) {
+func (h *Hnsw) Link(friendItem *Item, node *Node, level int) {
 	dist := node.VecDistFromNode(h.Nodes[friendItem.id])
 
 	// update both friends
@@ -192,7 +185,7 @@ func (h *Hnsw) Link(friendItem *Item, node *Node, level uint) {
 	}
 }
 
-func (h *Hnsw) findCloserEntryPoint(ep *Item, q Vector, qLevel uint) *Item {
+func (h *Hnsw) findCloserEntryPoint(ep *Item, q Vector, qLevel int) *Item {
 	for level := h.MaxLevel; level > qLevel; level-- {
 		friends := h.Nodes[ep.id].GetFriendsAtLevel(level)
 
@@ -223,6 +216,7 @@ func (h *Hnsw) Insert(q Vector) error {
 
 	// 3. make the second pass, this time create connections
 	for level := min(currentTopLevel, qLevel); level >= 0; level-- {
+		fmt.Printf("3rd pass LEVEL : %v\n", level)
 		nnToQAtLevel, err := h.searchLevel(q, newEpItem, h.EfConstruction, level)
 		if err != nil {
 			return fmt.Errorf("failed to make connections, %v", err)

--- a/pkg/hnsw/hnsw.go
+++ b/pkg/hnsw/hnsw.go
@@ -216,7 +216,6 @@ func (h *Hnsw) Insert(q Vector) error {
 
 	// 3. make the second pass, this time create connections
 	for level := min(currentTopLevel, qLevel); level >= 0; level-- {
-		fmt.Printf("3rd pass LEVEL : %v\n", level)
 		nnToQAtLevel, err := h.searchLevel(q, newEpItem, h.EfConstruction, level)
 		if err != nil {
 			return fmt.Errorf("failed to make connections, %v", err)

--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -69,9 +69,9 @@ func TestHnswSelect(t *testing.T) {
 
 		h := NewHNSW(32, 1, NewNode(0, []float64{0, 0}, 3))
 
-		_, err := h.selectNeighbors(candidates, 10)
-		if err == nil {
-			t.Fatalf("expected to fail!")
+		res, err := h.selectNeighbors(candidates, 10)
+		if err != nil || res.Len() != 3 {
+			t.Fatal("if num neighbors to return is greater than candidates, we should just be returning the candidates")
 		}
 	})
 }
@@ -277,7 +277,7 @@ func TestFindCloserEntryPoint(t *testing.T) {
 		m := NewNode(1, []float64{5, 5}, 9)
 		h.Nodes[m.id] = m
 
-		for level := uint(0); level <= 9; level++ {
+		for level := 0; level <= 9; level++ {
 			ep.InsertFriendsAtLevel(level, m.id, m.VecDistFromVec(q))
 		}
 
@@ -298,7 +298,7 @@ func TestFindCloserEntryPoint(t *testing.T) {
 		h := NewHNSW(32, 32, ep)
 
 		q := []float64{6, 6}
-		qLayer := uint(3)
+		qLayer := 3
 
 		// suppose we had m := []float{5, 5}. It is closer to q, so let's add m to the friends of ep
 		m := NewNode(1, []float64{5, 5}, 9)

--- a/pkg/hnsw/node.go
+++ b/pkg/hnsw/node.go
@@ -1,7 +1,6 @@
 package hnsw
 
 import (
-	"fmt"
 	"math"
 )
 
@@ -38,21 +37,20 @@ func NewNode(id NodeId, v Vector, level int) *Node {
 }
 
 // Must assert with HasLevel first
-func (n *Node) InsertFriendsAtLevel(level int, id NodeId, dist float64) {
-	n.friends[int(level)].Insert(id, dist)
+func (n0 *Node) InsertFriendsAtLevel(level int, id NodeId, dist float64) {
+	n0.friends[int(level)].Insert(id, dist)
 }
 
-func (n *Node) HasLevel(level int) bool {
+func (n0 *Node) HasLevel(level int) bool {
 	if level < 0 {
 		panic("level cannot be negative")
 	}
 
-	return len(n.friends)-1 >= int(level)
+	return len(n0.friends)-1 >= int(level)
 }
 
-func (n *Node) GetFriendsAtLevel(level int) *BaseQueue {
-	fmt.Printf("length of friends %v for level: %v\n", len(n.friends), level)
-	return n.friends[level]
+func (n0 *Node) GetFriendsAtLevel(level int) *BaseQueue {
+	return n0.friends[level]
 }
 
 func (n0 *Node) VecDistFromVec(v1 Vector) float64 {

--- a/pkg/hnsw/node.go
+++ b/pkg/hnsw/node.go
@@ -1,6 +1,9 @@
 package hnsw
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 type Vector []float64
 
@@ -12,13 +15,13 @@ type Node struct {
 	id NodeId
 	v  Vector
 
-	level uint
+	level int
 
 	// for every level, we have a list of friends' NodeIds
 	friends []*BaseQueue
 }
 
-func NewNode(id NodeId, v Vector, level uint) *Node {
+func NewNode(id NodeId, v Vector, level int) *Node {
 
 	friends := make([]*BaseQueue, level+1)
 
@@ -35,11 +38,11 @@ func NewNode(id NodeId, v Vector, level uint) *Node {
 }
 
 // Must assert with HasLevel first
-func (n *Node) InsertFriendsAtLevel(level uint, id NodeId, dist float64) {
+func (n *Node) InsertFriendsAtLevel(level int, id NodeId, dist float64) {
 	n.friends[int(level)].Insert(id, dist)
 }
 
-func (n *Node) HasLevel(level uint) bool {
+func (n *Node) HasLevel(level int) bool {
 	if level < 0 {
 		panic("level cannot be negative")
 	}
@@ -47,7 +50,8 @@ func (n *Node) HasLevel(level uint) bool {
 	return len(n.friends)-1 >= int(level)
 }
 
-func (n *Node) GetFriendsAtLevel(level uint) *BaseQueue {
+func (n *Node) GetFriendsAtLevel(level int) *BaseQueue {
+	fmt.Printf("length of friends %v for level: %v\n", len(n.friends), level)
 	return n.friends[level]
 }
 

--- a/pkg/hnsw/node_test.go
+++ b/pkg/hnsw/node_test.go
@@ -14,7 +14,7 @@ func TestWithinLevels(t *testing.T) {
 		n.friends[2] = NewBaseQueue(MinComparator{})
 
 		for i := 0; i < 3; i++ {
-			if !n.HasLevel(uint(i)) {
+			if !n.HasLevel(i) {
 				t.Fatalf("since n's max level is %v, all levels less should be true", n.level)
 			}
 		}
@@ -90,7 +90,7 @@ func TestNodeFriends(t *testing.T) {
 		qLayer := h.spawnLevel()
 		qNode := NewNode(1, []float64{3, 1}, qLayer)
 
-		if uint(len(qNode.friends)) != qLayer+1 {
+		if len(qNode.friends) != qLayer+1 {
 			t.Fatalf("expected the friends list to initialize to %v levels, got %v", qLayer+1, len(qNode.friends))
 		}
 	})


### PR DESCRIPTION
When we iterate through levels, specifically https://github.com/kevmo314/appendable/blob/main/pkg/hnsw/hnsw.go#L225

since level was a unsigned integer, we weren't iterating properly, as once level reached 0, it wraps around to the max value of `uint`.
