### PR TITLE
feat: multiple insertions of vectors, retrieve 10 closest

### DIFF
--- a/pkg/hnsw/hnsw.go
+++ b/pkg/hnsw/hnsw.go
@@ -158,7 +158,7 @@ func (h *Hnsw) KnnSearch(q Vector, kNeighborsToReturn, ef int) ([]*Item, error) 
 	}
 
 	if currentNearestElements.Len() < kNeighborsToReturn {
-		panic("")
+		return nil, fmt.Errorf("the currentNearestElement length %v", currentNearestElements.Len())
 	}
 
 	pq, err := currentNearestElements.Take(kNeighborsToReturn, MinComparator{})

--- a/pkg/hnsw/hnsw.go
+++ b/pkg/hnsw/hnsw.go
@@ -137,7 +137,7 @@ func (h *Hnsw) selectNeighbors(candidates *BaseQueue, numNeighborsToReturn int) 
 	return pq, nil
 }
 
-func (h *Hnsw) KnnSearch(q Vector, kNeighborsToReturn, ef int) ([]*Item, error) {
+func (h *Hnsw) KnnSearch(q Vector, kNeighborsToReturn, ef int) (*BaseQueue, error) {
 	currentNearestElements := NewBaseQueue(MinComparator{})
 	entryPointNode := h.Nodes[h.EntryNodeId]
 	entryPointItem := &Item{id: h.EntryNodeId, dist: entryPointNode.VecDistFromVec(q)}
@@ -166,7 +166,7 @@ func (h *Hnsw) KnnSearch(q Vector, kNeighborsToReturn, ef int) ([]*Item, error) 
 		return nil, fmt.Errorf("failed to knnsearch, err: %v", err)
 	}
 
-	return pq.items, nil
+	return pq, nil
 }
 
 func (h *Hnsw) Link(friendItem *Item, node *Node, level int) {

--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -117,6 +117,40 @@ func TestHnsw_Insert(t *testing.T) {
 		}
 	})
 
+	t.Run("multiple insert", func(t *testing.T) {
+		h := NewHNSW(10, 10, NewNode(0, []float64{0, 0}, 4))
+
+		for i := 0; i < 32; i++ {
+			if len(h.Nodes) != i+1 {
+				t.Fatalf("expected the number of nodes in graph to be %v, got %v", i+1, len(h.Nodes))
+			}
+
+			if err := h.Insert([]float64{float64(32 - i), float64(31 - i)}); err != nil {
+				t.Fatal(err)
+			}
+
+			if len(h.Nodes) != i+2 {
+				t.Fatalf("expected the number of nodes in graph to be %v, got %v", i+2, len(h.Nodes)+2)
+			}
+		}
+
+		items, err := h.KnnSearch([]float64{32, 31}, 10, 32)
+		if err != nil {
+			return
+		}
+
+		if len(items) != 32 {
+			t.Fatalf("expected to return %v neighbors, got: %v", 32, len(items))
+		}
+
+		expectedId := NodeId(1)
+
+		for _, item := range items {
+			if item.id != expectedId {
+				t.Fatalf("expected to find %v in %v", expectedId, item.id)
+			}
+		}
+	})
 }
 
 func TestHnsw_Link(t *testing.T) {

--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -139,17 +139,24 @@ func TestHnsw_Insert(t *testing.T) {
 			return
 		}
 
-		if len(items) != 32 {
-			t.Fatalf("expected to return %v neighbors, got: %v", 32, len(items))
+		if items.Len() != 10 {
+			t.Fatalf("expected to return %v neighbors, got: %v", 10, items.Len())
 		}
 
 		expectedId := NodeId(1)
 
-		for _, item := range items {
-			if item.id != expectedId {
-				t.Fatalf("expected to find %v in %v", expectedId, item.id)
+		for !items.IsEmpty() {
+			peeled, err := items.Peel()
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if peeled.id != expectedId {
+				t.Fatalf("expected %v, but got %v", expectedId, peeled.id)
 			}
 		}
+
 	})
 }
 

--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -118,7 +118,7 @@ func TestHnsw_Insert(t *testing.T) {
 	})
 
 	t.Run("multiple insert", func(t *testing.T) {
-		h := NewHNSW(10, 10, NewNode(0, []float64{0, 0}, 4))
+		h := NewHNSW(10, 10, NewNode(0, []float64{0, 0}, 40))
 
 		for i := 0; i < 32; i++ {
 			if len(h.Nodes) != i+1 {


### PR DESCRIPTION
We feed 32 vectors with the entry node as `[]float64{0, 0}`. As we iterate, the distances get further away from our q Vector: `[]float64{32, 32}`. 

We do a kNN search on `32, 32` and retrieve the 10 closest items