### PR TITLE
switch to float32

### DIFF
--- a/pkg/hnsw/eucqueue.go
+++ b/pkg/hnsw/eucqueue.go
@@ -25,19 +25,19 @@ func (c MinComparator) Less(i, j *Item) bool {
 
 type Item struct {
 	id    NodeId
-	dist  float64
+	dist  float32
 	index int
 }
 
 type Heapy interface {
 	heap.Interface
-	Insert(id NodeId, dist float64)
+	Insert(id NodeId, dist float32)
 	IsEmpty() bool
 	Len() int
 	Peel() *Item
 	Peek() *Item
 	Take(count int) (*BaseQueue, error)
-	update(item *Item, id NodeId, dist float64)
+	update(item *Item, id NodeId, dist float32)
 }
 
 // Nothing from BaseQueue should be used. Only use the Max and Min queue.
@@ -114,7 +114,7 @@ func (bq *BaseQueue) Less(i, j int) bool {
 	return bq.comparator.Less(bq.items[i], bq.items[j])
 }
 
-func (bq *BaseQueue) Insert(id NodeId, dist float64) {
+func (bq *BaseQueue) Insert(id NodeId, dist float32) {
 	if item, ok := bq.visitedIds[id]; ok {
 		bq.update(item, id, dist)
 		return
@@ -154,7 +154,7 @@ func (bq *BaseQueue) Peel() (*Item, error) {
 	return popped, nil
 }
 
-func (bq *BaseQueue) update(item *Item, id NodeId, dist float64) {
+func (bq *BaseQueue) update(item *Item, id NodeId, dist float32) {
 	item.id = id
 	item.dist = dist
 	heap.Fix(bq, item.index)

--- a/pkg/hnsw/eucqueue_test.go
+++ b/pkg/hnsw/eucqueue_test.go
@@ -1,6 +1,7 @@
 package hnsw
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -24,6 +25,7 @@ func TestEucQueue(t *testing.T) {
 
 		for i, v := range vs {
 			dist := EuclidDist(v0, v)
+			fmt.Printf("dist: %v", dist)
 			eq.Insert(NodeId(i), dist)
 
 			if i+1 != eq.Len() {
@@ -50,8 +52,12 @@ func TestEucQueue(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if item.id != expected[i].id || !NearlyEqual(item.dist, expected[i].dist) {
-				t.Fatalf("expected item %v, got %v at %v", expected[i].id, item.id, i)
+			if item.id != expected[i].id {
+				t.Fatalf("expected item id %v, got %v at %v", expected[i].id, item.id, i)
+			}
+
+			if !NearlyEqual(float64(item.dist), float64(expected[i].dist)) {
+				t.Fatalf("not equal, got %v, and %v", item.dist, expected[i].dist)
 			}
 
 			if _, ok := eq.visitedIds[item.id]; ok {
@@ -106,7 +112,7 @@ func TestEucQueue(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if item.id != expected[i].id || !NearlyEqual(item.dist, expected[i].dist) {
+			if item.id != expected[i].id || !NearlyEqual(float64(item.dist), float64(expected[i].dist)) {
 				t.Fatalf("expected item id: %v, got id: %v at i: %v", expected[i].id, item.id, i)
 			}
 
@@ -183,13 +189,13 @@ func TestEucQueue(t *testing.T) {
 		}, MinComparator{})
 
 		for i := 2; i <= 100; i++ {
-			mq.Insert(1, float64(i))
+			mq.Insert(1, float32(i))
 
 			if mq.Len() != 1 {
 				t.Fatalf("expected len to be %v, got %v", 1, mq.Len())
 			}
 
-			if !NearlyEqual(mq.Peek().dist, float64(i)) {
+			if !NearlyEqual(float64(mq.Peek().dist), float64(i)) {
 				t.Fatalf("expected distance to be the newly updated %v, got %v", i, mq.Peek().dist)
 			}
 		}
@@ -198,7 +204,7 @@ func TestEucQueue(t *testing.T) {
 			t.Fatalf("expected len to be %v, got %v", 1, mq.Len())
 		}
 
-		if !NearlyEqual(mq.Peek().dist, float64(100)) {
+		if !NearlyEqual(float64(mq.Peek().dist), float64(100)) {
 			t.Fatalf("expected distance to be the newly updated %v, got %v", 100, mq.Peek().dist)
 		}
 	})

--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestHnsw(t *testing.T) {
 	t.Run("builds graph", func(t *testing.T) {
-		n := NewNode(0, []float64{0.1, 0.2}, 3)
+		n := NewNode(0, []float32{0.1, 0.2}, 3)
 		h := NewHNSW(32, 32, n)
 
 		if h.MaxLevel != n.level {
@@ -32,7 +32,7 @@ func TestHnswSelect(t *testing.T) {
 			{id: 11, dist: 20},
 		}, MinComparator{})
 
-		h := NewHNSW(32, 1, NewNode(0, []float64{0, 0}, 3))
+		h := NewHNSW(32, 1, NewNode(0, []float32{0, 0}, 3))
 
 		cn, err := h.selectNeighbors(candidates, 10)
 
@@ -67,7 +67,7 @@ func TestHnswSelect(t *testing.T) {
 			{id: 3, dist: 8},
 		}, MinComparator{})
 
-		h := NewHNSW(32, 1, NewNode(0, []float64{0, 0}, 3))
+		h := NewHNSW(32, 1, NewNode(0, []float32{0, 0}, 3))
 
 		res, err := h.selectNeighbors(candidates, 10)
 		if err != nil || res.Len() != 3 {
@@ -79,7 +79,7 @@ func TestHnswSelect(t *testing.T) {
 func TestHnsw_Insert(t *testing.T) {
 
 	t.Run("nodes[0] is root", func(t *testing.T) {
-		n := NewNode(0, []float64{11, 11}, 3)
+		n := NewNode(0, []float32{11, 11}, 3)
 		h := NewHNSW(32, 32, n)
 
 		if len(h.Nodes) != 1 {
@@ -92,14 +92,14 @@ func TestHnsw_Insert(t *testing.T) {
 	})
 
 	t.Run("hnsw with inserted element q", func(t *testing.T) {
-		entryNode := NewNode(0, []float64{1, 1, 1}, 3)
+		entryNode := NewNode(0, []float32{1, 1, 1}, 3)
 		h := NewHNSW(32, 32, entryNode)
 
 		if len(h.Nodes) != 1 {
 			t.Fatalf("hnsw should be initialized with root node but got len: %v", len(h.Nodes))
 		}
 
-		err := h.Insert([]float64{1.3, 2.5, 2.3})
+		err := h.Insert([]float32{1.3, 2.5, 2.3})
 		if err != nil {
 			return
 		}
@@ -112,20 +112,20 @@ func TestHnsw_Insert(t *testing.T) {
 			t.Fatalf("expected node id at 1 to be initialized but got %v", h.Nodes[1].id)
 		}
 
-		if EuclidDist(h.Nodes[1].v, []float64{1.3, 2.5, 2.3}) != 0 {
-			t.Fatalf("incorrect vector inserted at %v expected vector %v but got %v", 1, []float64{1.3, 2.5, 2.3}, h.Nodes[1].v)
+		if EuclidDist(h.Nodes[1].v, []float32{1.3, 2.5, 2.3}) != 0 {
+			t.Fatalf("incorrect vector inserted at %v expected vector %v but got %v", 1, []float32{1.3, 2.5, 2.3}, h.Nodes[1].v)
 		}
 	})
 
 	t.Run("multiple insert", func(t *testing.T) {
-		h := NewHNSW(10, 10, NewNode(0, []float64{0, 0}, 40))
+		h := NewHNSW(10, 10, NewNode(0, []float32{0, 0}, 40))
 
 		for i := 0; i < 32; i++ {
 			if len(h.Nodes) != i+1 {
 				t.Fatalf("expected the number of nodes in graph to be %v, got %v", i+1, len(h.Nodes))
 			}
 
-			if err := h.Insert([]float64{float64(32 - i), float64(31 - i)}); err != nil {
+			if err := h.Insert([]float32{float32(32 - i), float32(31 - i)}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -134,7 +134,7 @@ func TestHnsw_Insert(t *testing.T) {
 			}
 		}
 
-		items, err := h.KnnSearch([]float64{32, 31}, 10, 32)
+		items, err := h.KnnSearch([]float32{32, 31}, 10, 32)
 		if err != nil {
 			return
 		}
@@ -212,13 +212,13 @@ func TestHnsw_Link(t *testing.T) {
 	})
 
 	t.Run("links correctly 2", func(t *testing.T) {
-		qNode := NewNode(1, []float64{4, 4}, 3)
+		qNode := NewNode(1, []float32{4, 4}, 3)
 
-		h := NewHNSW(1, 23, NewNode(0, []float64{0, 0}, 10))
+		h := NewHNSW(1, 23, NewNode(0, []float32{0, 0}, 10))
 
 		h.Nodes[qNode.id] = qNode
 
-		friends := [][]float64{
+		friends := [][]float32{
 			{2, 2}, {3, 3}, {3.5, 3.5},
 		}
 
@@ -280,7 +280,7 @@ func TestHnsw_Link(t *testing.T) {
 
 func TestNextNodeId(t *testing.T) {
 	t.Run("generate next node", func(t *testing.T) {
-		h := NewHNSW(30, 30, NewNode(0, []float64{}, 1))
+		h := NewHNSW(30, 30, NewNode(0, []float32{}, 1))
 		for i := 0; i <= 100; i++ {
 			nextNodeId := h.getNextNodeId()
 
@@ -293,10 +293,10 @@ func TestNextNodeId(t *testing.T) {
 
 func TestFindCloserEntryPoint(t *testing.T) {
 	t.Run("find nothing closer", func(t *testing.T) {
-		epNode := NewNode(0, []float64{0, 0}, 10)
+		epNode := NewNode(0, []float32{0, 0}, 10)
 		h := NewHNSW(32, 32, epNode)
 
-		qVector := []float64{6, 6}
+		qVector := []float32{6, 6}
 		qLevel := h.spawnLevel()
 
 		epItem := &Item{id: 0, dist: epNode.VecDistFromVec(qVector)}
@@ -308,14 +308,14 @@ func TestFindCloserEntryPoint(t *testing.T) {
 	})
 
 	t.Run("finds something closer traverse all layers", func(t *testing.T) {
-		ep := NewNode(0, []float64{0, 0}, 10)
+		ep := NewNode(0, []float32{0, 0}, 10)
 		h := NewHNSW(32, 32, ep)
 
-		q := []float64{6, 6}
+		q := []float32{6, 6}
 
 		// suppose we had m := []float{5, 5}. It is closer to q, so let's add m to the friends of ep
 
-		m := NewNode(1, []float64{5, 5}, 9)
+		m := NewNode(1, []float32{5, 5}, 9)
 		h.Nodes[m.id] = m
 
 		for level := 0; level <= 9; level++ {
@@ -335,20 +335,20 @@ func TestFindCloserEntryPoint(t *testing.T) {
 	})
 
 	t.Run("finds something closer during the insertion context", func(t *testing.T) {
-		ep := NewNode(0, []float64{0, 0}, 10)
+		ep := NewNode(0, []float32{0, 0}, 10)
 		h := NewHNSW(32, 32, ep)
 
-		q := []float64{6, 6}
+		q := []float32{6, 6}
 		qLayer := 3
 
 		// suppose we had m := []float{5, 5}. It is closer to q, so let's add m to the friends of ep
-		m := NewNode(1, []float64{5, 5}, 9)
+		m := NewNode(1, []float32{5, 5}, 9)
 		h.Nodes[m.id] = m
 		mDist := m.VecDistFromVec(q)
 
 		h.Link(&Item{id: m.id, dist: mDist}, h.Nodes[h.EntryNodeId], m.level)
 
-		n := NewNode(2, []float64{6.1, 6.1}, 4)
+		n := NewNode(2, []float32{6.1, 6.1}, 4)
 		h.Nodes[n.id] = n
 		nDist := n.VecDistFromNode(m)
 		h.Link(&Item{id: n.id, dist: nDist}, m, n.level)

--- a/pkg/hnsw/node.go
+++ b/pkg/hnsw/node.go
@@ -4,7 +4,7 @@ import (
 	"math"
 )
 
-type Vector []float64
+type Vector []float32
 
 type NodeId = uint32
 
@@ -37,7 +37,7 @@ func NewNode(id NodeId, v Vector, level int) *Node {
 }
 
 // Must assert with HasLevel first
-func (n0 *Node) InsertFriendsAtLevel(level int, id NodeId, dist float64) {
+func (n0 *Node) InsertFriendsAtLevel(level int, id NodeId, dist float32) {
 	n0.friends[int(level)].Insert(id, dist)
 }
 
@@ -46,20 +46,20 @@ func (n0 *Node) HasLevel(level int) bool {
 		panic("level cannot be negative")
 	}
 
-	return len(n0.friends)-1 >= int(level)
+	return len(n0.friends)-1 >= level
 }
 
 func (n0 *Node) GetFriendsAtLevel(level int) *BaseQueue {
 	return n0.friends[level]
 }
 
-func (n0 *Node) VecDistFromVec(v1 Vector) float64 {
+func (n0 *Node) VecDistFromVec(v1 Vector) float32 {
 	v0 := n0.v
 
 	return EuclidDist(v0, v1)
 }
 
-func (n0 *Node) VecDistFromNode(n1 *Node) float64 {
+func (n0 *Node) VecDistFromNode(n1 *Node) float32 {
 	// pull vec from nodes
 	v0 := n0.v
 	v1 := n1.v
@@ -67,20 +67,20 @@ func (n0 *Node) VecDistFromNode(n1 *Node) float64 {
 	return EuclidDist(v0, v1)
 }
 
-func EuclidDist(v0, v1 Vector) float64 {
+func EuclidDist(v0, v1 Vector) float32 {
 	// check if vector dimensionality is correct
 	if len(v0) != len(v1) {
 		panic("invalid lengths")
 	}
 
-	var sum float64
+	var sum float32
 
 	for i := range v0 {
-		delta := float64(v0[i] - v1[i])
+		delta := v0[i] - v1[i]
 		sum += delta * delta
 	}
 
-	return math.Sqrt(sum)
+	return float32(math.Sqrt(float64(sum)))
 }
 
 // NearlyEqual is sourced from scalar package written by gonum

--- a/pkg/hnsw/node_test.go
+++ b/pkg/hnsw/node_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestWithinLevels(t *testing.T) {
 	t.Run("levels are in bounds", func(t *testing.T) {
-		n := NewNode(3, []float64{3, 6, 9}, 3)
+		n := NewNode(3, []float32{3, 6, 9}, 3)
 
 		n.friends[0] = NewBaseQueue(MinComparator{})
 		n.friends[1] = NewBaseQueue(MinComparator{})
@@ -28,47 +28,47 @@ func TestWithinLevels(t *testing.T) {
 func TestVec(t *testing.T) {
 
 	type t_case struct {
-		u, v     []float64
+		u, v     []float32
 		expected float64
 	}
 
 	bank := [7]t_case{
 		{
-			u:        []float64{5, 3, 0},
-			v:        []float64{2, -2, math.Sqrt(2)},
+			u:        []float32{5, 3, 0},
+			v:        []float32{2, -2, float32(math.Sqrt(2))},
 			expected: 6,
 		},
 		{
-			u:        []float64{1, 0, -5},
-			v:        []float64{-3, 2, -1},
+			u:        []float32{1, 0, -5},
+			v:        []float32{-3, 2, -1},
 			expected: 6,
 		},
 		{
-			u:        []float64{1, 3},
-			v:        []float64{5, 2},
+			u:        []float32{1, 3},
+			v:        []float32{5, 2},
 			expected: math.Sqrt(17),
 		},
 		{
-			u:        []float64{0, 1, 4},
-			v:        []float64{2, 9, 1},
+			u:        []float32{0, 1, 4},
+			v:        []float32{2, 9, 1},
 			expected: math.Sqrt(77),
 		},
 		{
-			u:        []float64{0},
-			v:        []float64{0},
+			u:        []float32{0},
+			v:        []float32{0},
 			expected: 0,
 		},
 		{
-			u:        []float64{10, 20, 30, 40},
-			v:        []float64{10, 20, 30, 40},
-			expected: math.Sqrt(0),
+			u:        []float32{10, 20, 30, 40},
+			v:        []float32{10, 20, 30, 40},
+			expected: 0,
 		},
 	}
 
 	t.Run("correctly computes the dist from node", func(t *testing.T) {
 		for i, bank := range bank {
 
-			if !NearlyEqual(bank.expected, EuclidDist(bank.u, bank.v)) {
+			if !NearlyEqual(bank.expected, float64(EuclidDist(bank.u, bank.v))) {
 				t.Fatalf("err at %v, expected %v, got %v", i, bank.expected, EuclidDist(bank.u, bank.v))
 			}
 		}
@@ -77,7 +77,7 @@ func TestVec(t *testing.T) {
 	t.Run("symmetric", func(t *testing.T) {
 		for i, bank := range bank {
 
-			if !NearlyEqual(EuclidDist(bank.v, bank.u), EuclidDist(bank.u, bank.v)) {
+			if !NearlyEqual(float64(EuclidDist(bank.v, bank.u)), float64(EuclidDist(bank.u, bank.v))) {
 				t.Fatalf("err at %v, expected %v, got %v", i, bank.expected, EuclidDist(bank.u, bank.v))
 			}
 		}
@@ -86,9 +86,9 @@ func TestVec(t *testing.T) {
 
 func TestNodeFriends(t *testing.T) {
 	t.Run("initialized with correct # of levels", func(t *testing.T) {
-		h := NewHNSW(32, 32, NewNode(0, []float64{3, 4}, 8))
+		h := NewHNSW(32, 32, NewNode(0, []float32{3, 4}, 8))
 		qLayer := h.spawnLevel()
-		qNode := NewNode(1, []float64{3, 1}, qLayer)
+		qNode := NewNode(1, []float32{3, 1}, qLayer)
 
 		if len(qNode.friends) != qLayer+1 {
 			t.Fatalf("expected the friends list to initialize to %v levels, got %v", qLayer+1, len(qNode.friends))
@@ -96,7 +96,7 @@ func TestNodeFriends(t *testing.T) {
 	})
 
 	t.Run("correctly determines if has layer", func(t *testing.T) {
-		qNode := NewNode(10, []float64{3, 1, 0.3, 9.2}, 100)
+		qNode := NewNode(10, []float32{3, 1, 0.3, 9.2}, 100)
 
 		if !qNode.HasLevel(100) {
 			t.Fatalf("expected qNode to have level %v", 100)


### PR DESCRIPTION
Vectors and everything vector-related now use `Float32`. Other variables are kept as `Float64` due to their dependence on external dependencies like `math`.