### PR TITLE
feat: comment out flaky test

### DIFF
--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -413,6 +413,7 @@ func TestFindCloserEntryPoint(t *testing.T) {
 	})
 }
 
+/*
 func TestSpawnLevelDistribution(t *testing.T) {
 	t.Run("plot distribution", func(t *testing.T) {
 		h := NewHNSW(2, 12, 4, []float32{0, 0})
@@ -493,6 +494,7 @@ func TestSpawnLevelDistribution(t *testing.T) {
 		fmt.Printf("levels distribution: %v\n", levels)
 	})
 }
+*/
 
 func TestHnsw_KnnCluster(t *testing.T) {
 


### PR DESCRIPTION
These two commented test cases rely on randomness and the assertions use those random variables to check if the levels are non-decreasing. 

However, there are occurrences where this test case fails, which forces you to re-run a job. 

