### PR TITLE
feat: move child resolution to bptree node

### DIFF
--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -62,7 +62,7 @@ export class BTreeNode {
     return this.internalPointers.length + this.leafPointers.length;
   }
 
-  async readChildNode(index: number) {
+  async child(index: number) {
     const childPointer = this.pointer(index);
 
     const { node, bytesRead } = await BTreeNode.fromMemoryPointer(

--- a/src/btree/traversal.ts
+++ b/src/btree/traversal.ts
@@ -59,7 +59,7 @@ export class TraversalIterator {
         return false;
       }
       // propagate the rollover
-      this.records[i].node = await this.records[i + 1].node.readChildNode(
+      this.records[i].node = await this.records[i + 1].node.child(
         this.records[i + 1].index,
       );
 

--- a/src/btree/traversal.ts
+++ b/src/btree/traversal.ts
@@ -59,8 +59,8 @@ export class TraversalIterator {
         return false;
       }
       // propagate the rollover
-      this.records[i].node = await this.tree.readNode(
-        this.records[i + 1].node.pointer(this.records[i + 1].index),
+      this.records[i].node = await this.records[i + 1].node.readChildNode(
+        this.records[i + 1].index,
       );
 
       if (rolloverLeft) {


### PR DESCRIPTION
Step 2 in #313

Note, when we call `BPTreeNode.fromMemoryPointer()`, it creates a new node with attributes passed in.