### PR TITLE
sequential search with upper bound param

### DIFF
--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -476,6 +476,20 @@ func TestHnsw_InsertVector(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("524,288 points inserted", func(t *testing.T) {
+		numPoints := 524288
+
+		h := NewHnsw(2, 14, 14, Point{0, 0})
+		numPoints -= 1
+
+		for i := 0; i < numPoints; i++ {
+			if err := h.InsertVector(Point{float32(i + 1), float32(i + 1)}); err != nil {
+				t.Fatalf("failed to insert vector: %v", err)
+			}
+		}
+	})
+
 }
 
 func TestHnsw_KnnSearch(t *testing.T) {
@@ -596,6 +610,39 @@ func TestHnsw_KnnSearch(t *testing.T) {
 
 		if !reflect.DeepEqual(expected, got) {
 			t.Fatalf("expected closest points to be %v, got %v", expected, got)
+		}
+	})
+
+	t.Run("sequential search with upper bound params", func(t *testing.T) {
+		h := NewHnsw(2, 12, 12, Point{0, 0})
+		for i := 1; i <= 8; i++ {
+			if err := h.InsertVector(Point{float32(i), float32(i + 1)}); err != nil {
+				t.Fatalf("failed to insert point: %v, err: %v", Point{float32(i), float32(i + 1)}, err)
+			}
+		}
+
+		found, err := h.KnnSearch(Point{float32(0), float32(0)}, 10)
+
+		if err != nil {
+			t.Fatalf("failed to find closest neighbors: %v", err)
+		}
+
+		if found.Len() != 9 {
+			t.Fatalf("expected to find 9 closest neighbors, got %v", found.Len())
+		}
+
+		expectedId := Id(0)
+
+		for found.IsEmpty() {
+			nnItem, err := found.PopItem()
+			if err != nil {
+				t.Fatalf("failed to pop item: %v, err: %v", found, err)
+			}
+			if expectedId != nnItem.id {
+				t.Fatalf("expected to find %v, got %v", expectedId, nnItem.id)
+			}
+
+			expectedId += 1
 		}
 	})
 }

--- a/pkg/hnsw/hnsw_test.go
+++ b/pkg/hnsw/hnsw_test.go
@@ -477,19 +477,6 @@ func TestHnsw_InsertVector(t *testing.T) {
 		}
 	})
 
-	t.Run("524,288 points inserted", func(t *testing.T) {
-		numPoints := 524288
-
-		h := NewHnsw(2, 14, 14, Point{0, 0})
-		numPoints -= 1
-
-		for i := 0; i < numPoints; i++ {
-			if err := h.InsertVector(Point{float32(i + 1), float32(i + 1)}); err != nil {
-				t.Fatalf("failed to insert vector: %v", err)
-			}
-		}
-	})
-
 }
 
 func TestHnsw_KnnSearch(t *testing.T) {


### PR DESCRIPTION
Suppose we wanted to search for the 10 nearest elements, but the entire graph itself has only 9 elements. This PR seeks to make sure it returns the `Min(num points in graph, # nearest elements wanted)`