### PR TITLE
btree serialize

### DIFF
--- a/pkg/btree/btree.go
+++ b/pkg/btree/btree.go
@@ -1,0 +1,48 @@
+package btree
+
+import (
+	"github.com/kevmo314/appendable/pkg/metapage"
+	"github.com/kevmo314/appendable/pkg/pagefile"
+	"github.com/kevmo314/appendable/pkg/pointer"
+	"io"
+)
+
+type BTree struct {
+	MetaPage metapage.MetaPage
+	PageFile pagefile.ReadWriteSeekPager
+
+	Width uint16
+}
+
+func (t *BTree) root() (*BTreeNode, pointer.MemoryPointer, error) {
+	mp, err := t.MetaPage.Root()
+	if err != nil {
+		return nil, mp, err
+	}
+
+	root, err := t.readNode(mp.Offset)
+	if err != nil {
+		return nil, mp, err
+	}
+
+	return root, mp, nil
+}
+
+func (t *BTree) readNode(offset uint64) (*BTreeNode, error) {
+	if _, err := t.PageFile.Seek(int64(offset), io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	node := &BTreeNode{Width: t.Width}
+	buf := make([]byte, t.PageFile.PageSize())
+
+	if _, err := t.PageFile.Read(buf); err != nil {
+		return nil, err
+	}
+
+	if err := node.UnmarshalBinary(buf); err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}

--- a/pkg/btree/btree_test.go
+++ b/pkg/btree/btree_test.go
@@ -1,0 +1,1 @@
+package btree

--- a/pkg/btree/node.go
+++ b/pkg/btree/node.go
@@ -1,0 +1,39 @@
+package btree
+
+import (
+	"github.com/kevmo314/appendable/pkg/hnsw"
+	"io"
+)
+
+type BTreeNode struct {
+	Ids     []hnsw.Id
+	Vectors []hnsw.Point
+
+	Pointers []uint64
+	Width    uint16
+}
+
+func (n *BTreeNode) Size() int64 {
+	return 0
+}
+
+// MarshalBinary TODO!
+func (n *BTreeNode) MarshalBinary() ([]byte, error) {
+	b := []byte{}
+
+	return b, nil
+}
+
+// UnmarshalBinary TODO!
+func (n *BTreeNode) UnmarshalBinary(buf []byte) error {
+	return nil
+}
+
+func (n *BTreeNode) WriteTo(w io.Writer) (int64, error) {
+	buf, err := n.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	m, err := w.Write(buf)
+	return int64(m), err
+}

--- a/pkg/metapage/metapage.go
+++ b/pkg/metapage/metapage.go
@@ -1,6 +1,9 @@
 package metapage
 
-import "github.com/kevmo314/appendable/pkg/pointer"
+import (
+	"github.com/kevmo314/appendable/pkg/pointer"
+	"io"
+)
 
 // MetaPage is an abstract interface over the root page of a bptree
 // This allows the caller to control the memory location of the meta
@@ -8,4 +11,12 @@ import "github.com/kevmo314/appendable/pkg/pointer"
 type MetaPage interface {
 	Root() (pointer.MemoryPointer, error)
 	SetRoot(pointer.MemoryPointer) error
+}
+
+type NodeSerializable interface {
+	Size() int64
+	NumPointers() int
+	MarshalBinary() ([]byte, error)
+	UnmarshalBinary([]byte) error
+	WriteTo(w io.Writer) (int64, error)
 }


### PR DESCRIPTION
The methods below share disk-related operations used by `BPTree`. This PR adds the following function headers, as well as the structs.