### PR TITLE
add guard to `Size`

### DIFF
--- a/pkg/btree/node.go
+++ b/pkg/btree/node.go
@@ -32,6 +32,10 @@ func (n *BTreeNode) Size() int64 {
 		size += encoding.SizeVarint(n)
 	}
 
+	if n.VectorDim == 0 {
+		panic("VectorDim cannot be zero")
+	}
+
 	size += encoding.SizeVarint(n.VectorDim)
 	size += len(n.Vectors) * (4 * int(n.VectorDim))
 


### PR DESCRIPTION
A common trap when creating a `BTree` is to zero out `VectorDim`. However, a `VectorDim` of 0 proceeds to screw up the `Size` calculation. 

