### PR TITLE
feat: clone

### DIFF
--- a/pkg/hnsw/heap.go
+++ b/pkg/hnsw/heap.go
@@ -127,6 +127,23 @@ func NewDistHeap() *DistHeap {
 	return d
 }
 
+func (d *DistHeap) Clone() *DistHeap {
+	n := &DistHeap{
+		items:   make([]*Item, len(d.items)),
+		visited: make(map[Id]int, len(d.visited)),
+	}
+
+	for i, item := range d.items {
+		n.items[i] = &*item
+	}
+
+	for id, index := range d.visited {
+		n.visited[id] = index
+	}
+
+	return n
+}
+
 func (d *DistHeap) PeekMinItem() (*Item, error) {
 	if d.IsEmpty() {
 		return nil, EmptyHeapError

--- a/pkg/hnsw/heap.go
+++ b/pkg/hnsw/heap.go
@@ -2,6 +2,7 @@ package hnsw
 
 import (
 	"fmt"
+	"maps"
 	"math/bits"
 )
 
@@ -133,13 +134,8 @@ func (d *DistHeap) Clone() *DistHeap {
 		visited: make(map[Id]int, len(d.visited)),
 	}
 
-	for i, item := range d.items {
-		n.items[i] = &*item
-	}
-
-	for id, index := range d.visited {
-		n.visited[id] = index
-	}
+	copy(n.items, d.items)
+	maps.Copy(n.visited, d.visited)
 
 	return n
 }

--- a/pkg/hnsw/heap_test.go
+++ b/pkg/hnsw/heap_test.go
@@ -1,6 +1,9 @@
 package hnsw
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestHeap(t *testing.T) {
 
@@ -136,6 +139,34 @@ func TestHeap(t *testing.T) {
 			if res != c.expected {
 				t.Errorf("got %d, want %d", res, c.expected)
 			}
+		}
+	})
+
+	t.Run("copy", func(t *testing.T) {
+		m := NewDistHeap()
+
+		for i := 0; i <= 10; i++ {
+			m.Insert(Id(i), float32(10-i))
+		}
+
+		n := m.Clone()
+
+		reflect.DeepEqual(m.items, n.items)
+		reflect.DeepEqual(m.visited, n.visited)
+
+		expectedId := Id(10)
+
+		for !n.IsEmpty() {
+			item, err := n.PopMinItem()
+			if err != nil {
+				return
+			}
+
+			if item.id != expectedId {
+				t.Fatalf("expected id to be %v, got %v", expectedId, item.id)
+			}
+
+			expectedId -= 1
 		}
 	})
 }


### PR DESCRIPTION
When flushing the `Friends` to disk, we need a non-mutable way to traverse through the `DistHeap`. This PR contains the `Clone()` function which will perform a deep copy of the `DistHeap`. 

