### PR TITLE
feat: refactor vector manager

### DIFF
--- a/pkg/hnsw/hnsw.go
+++ b/pkg/hnsw/hnsw.go
@@ -27,6 +27,15 @@ type Hnsw struct {
 	M, Mmax0 int
 }
 
+func (h *Hnsw) Neighborhood(id Id) (*Friends, error) {
+	friends, ok := h.friends[id]
+	if !ok {
+		return nil, ErrNodeNotFound
+	}
+
+	return friends, nil
+}
+
 func NewHnsw(d int, efConstruction int, M int, entryPoint Point) *Hnsw {
 	if d <= 0 || len(entryPoint) != d {
 		panic("invalid vector dimensionality")


### PR DESCRIPTION
Follow up from yesterday's 1-1:

The `VectorPageManager` should encapsulate the `hnsw`. As we iterate by table row, the `VectorPageManager` is responsible for updating the `hnsw`, then serializing the node state to disk.

Note this is a highly stateful action as we don't know a node's `closest` friends until all other nodes have been `considered`.